### PR TITLE
Avoiding TLS/CA race condition on Capsule installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,3 +5,7 @@ k8s:
 .PHONY: crds
 crds:
 	operator-sdk generate crds
+
+.PHONY: docker-image
+docker-image:
+	operator-sdk build quay.io/clastix/capsule:latest

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -71,7 +71,6 @@ func main() {
 	// controller-runtime)
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 
-
 	var v bool
 	pflag.BoolVarP(&v, "version", "v", false, "Print the Capsule version and exit")
 

--- a/pkg/cert/ca.go
+++ b/pkg/cert/ca.go
@@ -38,7 +38,7 @@ func (c CapsuleCa) ExpiresIn(now time.Time) (time.Duration, error) {
 	if !c.isAlreadyValid(now) {
 		return time.Nanosecond, CaNotYetValidError{}
 	}
-	return time.Duration(c.ca.NotAfter.Unix() - now.Unix()) * time.Second, nil
+	return time.Duration(c.ca.NotAfter.Unix()-now.Unix()) * time.Second, nil
 }
 
 func (c CapsuleCa) CaCertificatePem() (b *bytes.Buffer, err error) {
@@ -108,7 +108,7 @@ func NewCertificateAuthorityFromBytes(certBytes, keyBytes []byte) (s *CapsuleCa,
 	}
 
 	s = &CapsuleCa{
-		ca: cert,
+		ca:         cert,
 		privateKey: key,
 	}
 

--- a/pkg/cert/ca_test.go
+++ b/pkg/cert/ca_test.go
@@ -19,7 +19,7 @@ func TestNewCertificateAuthorityFromBytes(t *testing.T) {
 	assert.Nil(t, err)
 
 	var crt *bytes.Buffer
-	crt, err =ca.CaCertificatePem()
+	crt, err = ca.CaCertificatePem()
 	assert.Nil(t, err)
 
 	var key *bytes.Buffer

--- a/pkg/cert/errors.go
+++ b/pkg/cert/errors.go
@@ -1,12 +1,12 @@
 package cert
 
-type CaNotYetValidError struct {}
+type CaNotYetValidError struct{}
 
 func (CaNotYetValidError) Error() string {
 	return "The current CA is not yet valid"
 }
 
-type CaExpiredError struct {}
+type CaExpiredError struct{}
 
 func (CaExpiredError) Error() string {
 	return "The current CA is expired"

--- a/pkg/controller/secret/errors.go
+++ b/pkg/controller/secret/errors.go
@@ -1,0 +1,8 @@
+package secret
+
+type MissingCaError struct {
+}
+
+func (MissingCaError) Error() string {
+	return "CA has not been created yet, please generate a new"
+}

--- a/pkg/controller/secret/reconciler.go
+++ b/pkg/controller/secret/reconciler.go
@@ -63,17 +63,7 @@ func (r *ReconcileSecret) GetCertificateAuthority() (ca cert.Ca, err error) {
 	}
 
 	if instance.Data == nil {
-		ca, err = cert.GenerateCertificateAuthority()
-		if err != nil {
-			return
-		}
-
-		instance.Data = map[string][]byte{}
-
-		crt, _ := ca.CaCertificatePem()
-		instance.Data[Cert] = crt.Bytes()
-		key, _ := ca.CaPrivateKeyPem()
-		instance.Data[PrivateKey] = key.Bytes()
+		return nil, MissingCaError{}
 	}
 
 	ca, err = cert.NewCertificateAuthorityFromBytes(instance.Data[Cert], instance.Data[PrivateKey])

--- a/pkg/controller/secret/secret_tls_controller.go
+++ b/pkg/controller/secret/secret_tls_controller.go
@@ -130,7 +130,7 @@ func tlsReconcile(r *ReconcileSecret, request reconcile.Request) (reconcile.Resu
 	}
 
 	var res controllerutil.OperationResult
-	t := &corev1.Secret{ObjectMeta: instance.ObjectMeta,}
+	t := &corev1.Secret{ObjectMeta: instance.ObjectMeta}
 	res, err = controllerutil.CreateOrUpdate(context.TODO(), r.client, t, func() error {
 		t.Data = instance.Data
 		return nil

--- a/pkg/controller/tenant/tenant_controller.go
+++ b/pkg/controller/tenant/tenant_controller.go
@@ -62,7 +62,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	}
 
 	// Watch for changes to primary resource Tenant
-	err = c.Watch(&source.Kind{Type: &capsulev1alpha1.Tenant{}}, &handler.EnqueueRequestForObject{}, )
+	err = c.Watch(&source.Kind{Type: &capsulev1alpha1.Tenant{}}, &handler.EnqueueRequestForObject{})
 	if err != nil {
 		return err
 	}

--- a/pkg/webhook/owner_reference/patching.go
+++ b/pkg/webhook/owner_reference/patching.go
@@ -56,7 +56,6 @@ func (r *ownerRef) Handle(ctx context.Context, req admission.Request) admission.
 		return admission.Errored(http.StatusBadRequest, err)
 	}
 
-
 	g := utils.UserGroupList(req.UserInfo.Groups)
 	if !g.IsInCapsuleGroup() {
 		// user requested NS creation is not a Capsule user, so skipping the validation checks


### PR DESCRIPTION
Closes #6.

The `GetCertificateAuthority` _Reconciler_ func was also creating a new CA without storing into Kubernetes, causing a race condition, getting a TLS generated from a CA that wasn't used by the mutating webhook configuration.