### PR TITLE
NetworkPolicy validating webhook logic was the opposite

### DIFF
--- a/pkg/webhook/network_policies/validating.go
+++ b/pkg/webhook/network_policies/validating.go
@@ -68,7 +68,7 @@ func (r *handler) OnDelete(ctx context.Context, req admission.Request, client cl
 	if err != nil {
 		return admission.Errored(http.StatusInternalServerError, err)
 	}
-	if !ok {
+	if ok {
 		return admission.Denied("Capsule Network Policies cannot be deleted: please, reach out the system administrators")
 	}
 
@@ -86,7 +86,7 @@ func (r *handler) OnUpdate(ctx context.Context, req admission.Request, client cl
 	if err != nil {
 		return admission.Errored(http.StatusInternalServerError, err)
 	}
-	if !ok {
+	if ok {
 		return admission.Denied("Capsule Network Policies cannot be updated: please, reach out the system administrators")
 	}
 


### PR DESCRIPTION
Closes #32.

Tenant owner was able to delete or update Capsule NetworkPolicy resources instead of their owns.