### PR TITLE
Implementing Capsule certificate validation

### DIFF
--- a/pkg/cert/ca.go
+++ b/pkg/cert/ca.go
@@ -32,11 +32,23 @@ type Ca interface {
 	CaCertificatePem() (b *bytes.Buffer, err error)
 	CaPrivateKeyPem() (b *bytes.Buffer, err error)
 	ExpiresIn(now time.Time) (time.Duration, error)
+	ValidateCert(certificate *x509.Certificate) error
 }
 
 type CapsuleCa struct {
 	ca         *x509.Certificate
 	privateKey *rsa.PrivateKey
+}
+
+func (c CapsuleCa) ValidateCert(certificate *x509.Certificate) (err error) {
+	pool := x509.NewCertPool()
+	pool.AddCert(c.ca)
+
+	_, err = certificate.Verify(x509.VerifyOptions{
+		Roots:       pool,
+		CurrentTime: time.Time{},
+	})
+	return
 }
 
 func (c CapsuleCa) isAlreadyValid(now time.Time) bool {


### PR DESCRIPTION
Closes #42: essentially, we're validating the certificate at each Capsule start-up, generating a new one in case of CA change for any reason.