### PR TITLE
Adding zap controlled by CLI flags

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -27,6 +27,8 @@ spec:
         - /manager
         args:
         - --enable-leader-election
+        - --zap-encoder=console
+        - --zap-log-level=debug
         image: quay.io/clastix/capsule:latest
         imagePullPolicy: IfNotPresent
         name: manager

--- a/contributing.md
+++ b/contributing.md
@@ -171,9 +171,10 @@ I0803 15:16:02.042022       1 main.go:281] Starting TCP socket on 0.0.0.0:8443
 I0803 15:16:02.042364       1 main.go:288] Listening securely on 0.0.0.0:8443
 ```
 
-Since Capsule is built using _OperatorSDK_, logging is handled by the zap
+Since Capsule is built using _OperatorSDK_, logging is handled by the `zap`
 module: verbosity increase can be controlled using the CLI flag `--zap-level`
-with a value from `1` to `10` or the [basic keywords](https://godoc.org/go.uber.org/zap/zapcore#Level).
+with a value from `1` to `10` or the [basic keywords](https://godoc.org/go.uber.org/zap/zapcore#Level)
+although is suggested to use the `zap-devel` flag to get also stacktraces.
 
 > CA generation
 >

--- a/main.go
+++ b/main.go
@@ -78,9 +78,11 @@ func main() {
 	flag.BoolVar(&forceTenantPrefix, "force-tenant-prefix", false, "Enforces the Tenant owner, "+
 		"during Namespace creation, to name it using the selected Tenant name as prefix, separated by a dash. "+
 		"This is useful to avoid Namespace name collision in a public CaaS environment.")
+	opts := zap.Options{}
+	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
 
-	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
+	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
 	printVersion()
 	if v {


### PR DESCRIPTION
Closes #46.

All the pieces of information have been provided by the [following doc](https://sdk.operatorframework.io/docs/golang/references/logging).