### PR TITLE
Add protected-namespace-regex flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ Log verbosity of the Capsule controller can be increased by passing the `--zap-l
 
 During startup Capsule controller will create additional ClusterRoles `capsule-namespace:deleter`, `capsule-namespace:provisioner` and ClusterRoleBinding `capsule-namespace:provisioner`. These resources are used in order to allow Capsule users to manage their namespaces in tenants.
 
+You can disallow users to create namespaces matching a particular regexp by passing `--protected-namespace-regex` option with a value of regular expression.
+
 ## Admission Controllers
 Capsule implements Kubernetes multi-tenancy capabilities using a minimum set of standard [Admission Controllers](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/) enabled on the Kubernetes APIs server: `--enable-admission-plugins=PodNodeSelector,LimitRanger,ResourceQuota,MutatingAdmissionWebhook,ValidatingAdmissionWebhook`. In addition to these default controllers, Capsule implements its own set of Admission Controllers through the [Dynamic Admission Controller](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/), providing callbacks to add further validation or resource patching.
 

--- a/e2e/custom_capsule_group_test.go
+++ b/e2e/custom_capsule_group_test.go
@@ -54,16 +54,16 @@ var _ = Describe("creating a Namespace as Tenant owner with custom --capsule-gro
 	It("should fail", func() {
 		args := append(defaulManagerPodArgs, []string{"--capsule-user-group=test"}...)
 		ModifyCapsuleManagerPodArgs(args)
-		CapsuleClusterGroupParamShouldBeUpdated("test")
+		CapsuleClusterGroupParamShouldBeUpdated("test", podRecreationTimeoutInterval)
 		ns := NewNamespace("cg-namespace-fail")
-		NamespaceCreationShouldNotSucceed(ns, tnt)
+		NamespaceCreationShouldNotSucceed(ns, tnt, podRecreationTimeoutInterval)
 	})
 	It("should succeed and be available in Tenant namespaces list", func() {
 		ModifyCapsuleManagerPodArgs(defaulManagerPodArgs)
-		CapsuleClusterGroupParamShouldBeUpdated("capsule.clastix.io")
+		CapsuleClusterGroupParamShouldBeUpdated("capsule.clastix.io", podRecreationTimeoutInterval)
 		ns := NewNamespace("cg-namespace")
-		NamespaceCreationShouldSucceed(ns, tnt)
-		NamespaceShouldBeManagedByTenant(ns, tnt)
+		NamespaceCreationShouldSucceed(ns, tnt, podRecreationTimeoutInterval)
+		NamespaceShouldBeManagedByTenant(ns, tnt, podRecreationTimeoutInterval)
 
 	})
 })

--- a/e2e/ingress_class_test.go
+++ b/e2e/ingress_class_test.go
@@ -65,8 +65,8 @@ var _ = Describe("when Tenant handles Ingress classes", func() {
 		ns := NewNamespace("ingress-class-disallowed")
 		cs := ownerClient(tnt)
 
-		NamespaceCreationShouldSucceed(ns, tnt)
-		NamespaceShouldBeManagedByTenant(ns, tnt)
+		NamespaceCreationShouldSucceed(ns, tnt, defaultTimeoutInterval)
+		NamespaceShouldBeManagedByTenant(ns, tnt, defaultTimeoutInterval)
 
 		By("non-specifying the class", func() {
 			Eventually(func() (err error) {
@@ -128,8 +128,8 @@ var _ = Describe("when Tenant handles Ingress classes", func() {
 		ns := NewNamespace("ingress-class-allowed-annotation")
 		cs := ownerClient(tnt)
 
-		NamespaceCreationShouldSucceed(ns, tnt)
-		NamespaceShouldBeManagedByTenant(ns, tnt)
+		NamespaceCreationShouldSucceed(ns, tnt, defaultTimeoutInterval)
+		NamespaceShouldBeManagedByTenant(ns, tnt, defaultTimeoutInterval)
 
 		for _, c := range tnt.Spec.IngressClasses {
 			Eventually(func() (err error) {
@@ -168,8 +168,8 @@ var _ = Describe("when Tenant handles Ingress classes", func() {
 			Skip("Running test ont Kubernetes " + v.String() + ", doesn't provide .spec.ingressClassName")
 		}
 
-		NamespaceCreationShouldSucceed(ns, tnt)
-		NamespaceShouldBeManagedByTenant(ns, tnt)
+		NamespaceCreationShouldSucceed(ns, tnt, defaultTimeoutInterval)
+		NamespaceShouldBeManagedByTenant(ns, tnt, defaultTimeoutInterval)
 
 		for _, c := range tnt.Spec.IngressClasses {
 			Eventually(func() (err error) {

--- a/e2e/overquota_namespace_test.go
+++ b/e2e/overquota_namespace_test.go
@@ -54,8 +54,8 @@ var _ = Describe("creating a Namespace over-quota", func() {
 		By("creating three Namespaces", func() {
 			for _, name := range []string{"bob-dev", "bob-staging", "bob-production"} {
 				ns := NewNamespace(name)
-				NamespaceCreationShouldSucceed(ns, tnt)
-				NamespaceShouldBeManagedByTenant(ns, tnt)
+				NamespaceCreationShouldSucceed(ns, tnt, defaultTimeoutInterval)
+				NamespaceShouldBeManagedByTenant(ns, tnt, defaultTimeoutInterval)
 			}
 		})
 

--- a/e2e/owner_webhooks_test.go
+++ b/e2e/owner_webhooks_test.go
@@ -103,8 +103,8 @@ var _ = Describe("when Tenant owner interacts with the webhooks", func() {
 	It("should disallow deletions", func() {
 		By("blocking Capsule Limit ranges", func() {
 			ns := NewNamespace("limit-range-disallow")
-			NamespaceCreationShouldSucceed(ns, tnt)
-			NamespaceShouldBeManagedByTenant(ns, tnt)
+			NamespaceCreationShouldSucceed(ns, tnt, defaultTimeoutInterval)
+			NamespaceShouldBeManagedByTenant(ns, tnt, defaultTimeoutInterval)
 
 			lr := &corev1.LimitRange{}
 			Eventually(func() error {
@@ -117,8 +117,8 @@ var _ = Describe("when Tenant owner interacts with the webhooks", func() {
 		})
 		By("blocking Capsule Network Policy", func() {
 			ns := NewNamespace("network-policy-disallow")
-			NamespaceCreationShouldSucceed(ns, tnt)
-			NamespaceShouldBeManagedByTenant(ns, tnt)
+			NamespaceCreationShouldSucceed(ns, tnt, defaultTimeoutInterval)
+			NamespaceShouldBeManagedByTenant(ns, tnt, defaultTimeoutInterval)
 
 			np := &networkingv1.NetworkPolicy{}
 			Eventually(func() error {
@@ -131,8 +131,8 @@ var _ = Describe("when Tenant owner interacts with the webhooks", func() {
 		})
 		By("blocking blocking Capsule Resource Quota", func() {
 			ns := NewNamespace("resource-quota-disallow")
-			NamespaceCreationShouldSucceed(ns, tnt)
-			NamespaceShouldBeManagedByTenant(ns, tnt)
+			NamespaceCreationShouldSucceed(ns, tnt, defaultTimeoutInterval)
+			NamespaceShouldBeManagedByTenant(ns, tnt, defaultTimeoutInterval)
 
 			rq := &corev1.ResourceQuota{}
 			Eventually(func() error {
@@ -147,8 +147,8 @@ var _ = Describe("when Tenant owner interacts with the webhooks", func() {
 	It("should allow listing", func() {
 		By("Limit Range resources", func() {
 			ns := NewNamespace("limit-range-list")
-			NamespaceCreationShouldSucceed(ns, tnt)
-			NamespaceShouldBeManagedByTenant(ns, tnt)
+			NamespaceCreationShouldSucceed(ns, tnt, defaultTimeoutInterval)
+			NamespaceShouldBeManagedByTenant(ns, tnt, defaultTimeoutInterval)
 
 			Eventually(func() (err error) {
 				cs := ownerClient(tnt)
@@ -158,8 +158,8 @@ var _ = Describe("when Tenant owner interacts with the webhooks", func() {
 		})
 		By("Network Policy resources", func() {
 			ns := NewNamespace("network-policy-list")
-			NamespaceCreationShouldSucceed(ns, tnt)
-			NamespaceShouldBeManagedByTenant(ns, tnt)
+			NamespaceCreationShouldSucceed(ns, tnt, defaultTimeoutInterval)
+			NamespaceShouldBeManagedByTenant(ns, tnt, defaultTimeoutInterval)
 
 			Eventually(func() (err error) {
 				cs := ownerClient(tnt)
@@ -169,8 +169,8 @@ var _ = Describe("when Tenant owner interacts with the webhooks", func() {
 		})
 		By("Resource Quota resources", func() {
 			ns := NewNamespace("resource-quota-list")
-			NamespaceCreationShouldSucceed(ns, tnt)
-			NamespaceShouldBeManagedByTenant(ns, tnt)
+			NamespaceCreationShouldSucceed(ns, tnt, defaultTimeoutInterval)
+			NamespaceShouldBeManagedByTenant(ns, tnt, defaultTimeoutInterval)
 
 			Eventually(func() (err error) {
 				cs := ownerClient(tnt)
@@ -181,8 +181,8 @@ var _ = Describe("when Tenant owner interacts with the webhooks", func() {
 	})
 	It("should allow all actions to Tenant owner Network Policy resources", func() {
 		ns := NewNamespace("network-policy-allow")
-		NamespaceCreationShouldSucceed(ns, tnt)
-		NamespaceShouldBeManagedByTenant(ns, tnt)
+		NamespaceCreationShouldSucceed(ns, tnt, defaultTimeoutInterval)
+		NamespaceShouldBeManagedByTenant(ns, tnt, defaultTimeoutInterval)
 
 		cs := ownerClient(tnt)
 		np := &networkingv1.NetworkPolicy{

--- a/e2e/resource_quota_exceeded_test.go
+++ b/e2e/resource_quota_exceeded_test.go
@@ -91,8 +91,8 @@ var _ = Describe("exceeding Tenant resource quota", func() {
 				},
 			},
 			NetworkPolicies: []networkingv1.NetworkPolicySpec{},
-			NamespaceQuota: 2,
-			NodeSelector: map[string]string{},
+			NamespaceQuota:  2,
+			NodeSelector:    map[string]string{},
 			ResourceQuota: []corev1.ResourceQuotaSpec{
 				{
 					Hard: map[corev1.ResourceName]resource.Quantity{
@@ -125,8 +125,8 @@ var _ = Describe("exceeding Tenant resource quota", func() {
 		By("creating the Namespaces", func() {
 			for _, i := range nsl {
 				ns := NewNamespace(i)
-				NamespaceCreationShouldSucceed(ns, tnt)
-				NamespaceShouldBeManagedByTenant(ns, tnt)
+				NamespaceCreationShouldSucceed(ns, tnt, defaultTimeoutInterval)
+				NamespaceShouldBeManagedByTenant(ns, tnt, defaultTimeoutInterval)
 			}
 		})
 	})
@@ -157,7 +157,7 @@ var _ = Describe("exceeding Tenant resource quota", func() {
 							Spec: corev1.PodSpec{
 								Containers: []corev1.Container{
 									{
-										Name: "my-pause",
+										Name:  "my-pause",
 										Image: "gcr.io/google_containers/pause-amd64:3.0",
 									},
 								},
@@ -204,7 +204,7 @@ var _ = Describe("exceeding Tenant resource quota", func() {
 							Spec: corev1.PodSpec{
 								Containers: []corev1.Container{
 									{
-										Name: "my-exceeded",
+										Name:  "my-exceeded",
 										Image: "gcr.io/google_containers/pause-amd64:3.0",
 									},
 								},

--- a/e2e/selecting_tenant_test.go
+++ b/e2e/selecting_tenant_test.go
@@ -75,7 +75,7 @@ var _ = Describe("creating a Namespace with Tenant selector", func() {
 				l: t2.Name,
 			}
 		})
-		NamespaceCreationShouldSucceed(ns, t2)
-		NamespaceShouldBeManagedByTenant(ns, t2)
+		NamespaceCreationShouldSucceed(ns, t2, defaultTimeoutInterval)
+		NamespaceShouldBeManagedByTenant(ns, t2, defaultTimeoutInterval)
 	})
 })

--- a/e2e/storage_class_test.go
+++ b/e2e/storage_class_test.go
@@ -60,8 +60,8 @@ var _ = Describe("when Tenant handles Storage classes", func() {
 	})
 	It("should block non allowed Storage Class", func() {
 		ns := NewNamespace("storage-class-disallowed")
-		NamespaceCreationShouldSucceed(ns, tnt)
-		NamespaceShouldBeManagedByTenant(ns, tnt)
+		NamespaceCreationShouldSucceed(ns, tnt, defaultTimeoutInterval)
+		NamespaceShouldBeManagedByTenant(ns, tnt, defaultTimeoutInterval)
 
 		By("non-specifying the class", func() {
 			Eventually(func() (err error) {
@@ -108,8 +108,8 @@ var _ = Describe("when Tenant handles Storage classes", func() {
 		ns := NewNamespace("storage-class-allowed")
 		cs := ownerClient(tnt)
 
-		NamespaceCreationShouldSucceed(ns, tnt)
-		NamespaceShouldBeManagedByTenant(ns, tnt)
+		NamespaceCreationShouldSucceed(ns, tnt, defaultTimeoutInterval)
+		NamespaceShouldBeManagedByTenant(ns, tnt, defaultTimeoutInterval)
 
 		for _, c := range tnt.Spec.StorageClasses {
 			Eventually(func() (err error) {

--- a/e2e/tenant_resources_changes_test.go
+++ b/e2e/tenant_resources_changes_test.go
@@ -168,8 +168,8 @@ var _ = Describe("changing Tenant managed Kubernetes resources", func() {
 		By("creating the Namespaces", func() {
 			for _, i := range nsl {
 				ns := NewNamespace(i)
-				NamespaceCreationShouldSucceed(ns, tnt)
-				NamespaceShouldBeManagedByTenant(ns, tnt)
+				NamespaceCreationShouldSucceed(ns, tnt, defaultTimeoutInterval)
+				NamespaceShouldBeManagedByTenant(ns, tnt, defaultTimeoutInterval)
 			}
 		})
 	})

--- a/e2e/tenant_resources_test.go
+++ b/e2e/tenant_resources_test.go
@@ -27,7 +27,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/api/networking/v1"
+	v1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -170,8 +170,8 @@ var _ = Describe("creating namespaces within a Tenant with resources", func() {
 		By("creating the Namespaces", func() {
 			for _, i := range nsl {
 				ns := NewNamespace(i)
-				NamespaceCreationShouldSucceed(ns, tnt)
-				NamespaceShouldBeManagedByTenant(ns, tnt)
+				NamespaceCreationShouldSucceed(ns, tnt, defaultTimeoutInterval)
+				NamespaceShouldBeManagedByTenant(ns, tnt, defaultTimeoutInterval)
 			}
 		})
 	})


### PR DESCRIPTION
This PR closes #72 and adds configuration parameter `protected-namespace-regex` which disallow users to create namespaces whose name matches this regexp.

It's completely backward-compatible, as default `protected-namespace-regex` is set to empty string.