### PR TITLE
Making Namespace no more hard-coded

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -29,6 +29,11 @@ spec:
         - --enable-leader-election
         - --zap-encoder=console
         - --zap-log-level=debug
+        env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: quay.io/clastix/capsule:latest
         imagePullPolicy: IfNotPresent
         name: manager

--- a/controllers/secret/reconciler.go
+++ b/controllers/secret/reconciler.go
@@ -30,11 +30,11 @@ import (
 	"github.com/clastix/capsule/pkg/cert"
 )
 
-func getCertificateAuthority(client client.Client) (ca cert.Ca, err error) {
+func getCertificateAuthority(client client.Client, namespace string) (ca cert.Ca, err error) {
 	instance := &corev1.Secret{}
 
 	err = client.Get(context.TODO(), types.NamespacedName{
-		Namespace: "capsule-system",
+		Namespace: namespace,
 		Name:      caSecretName,
 	}, instance)
 	if err != nil {

--- a/controllers/secret/tls.go
+++ b/controllers/secret/tls.go
@@ -36,8 +36,9 @@ import (
 
 type TlsReconciler struct {
 	client.Client
-	Log    logr.Logger
-	Scheme *runtime.Scheme
+	Log       logr.Logger
+	Scheme    *runtime.Scheme
+	Namespace string
 }
 
 func (r *TlsReconciler) SetupWithManager(mgr ctrl.Manager) error {
@@ -63,7 +64,7 @@ func (r TlsReconciler) Reconcile(request ctrl.Request) (ctrl.Result, error) {
 	var ca cert.Ca
 	var rq time.Duration
 
-	ca, err = getCertificateAuthority(r.Client)
+	ca, err = getCertificateAuthority(r.Client, r.Namespace)
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/main.go
+++ b/main.go
@@ -76,6 +76,7 @@ func main() {
 	var capsuleGroup string
 	var protectedNamespaceRegexpString string
 	var protectedNamespaceRegexp *regexp.Regexp
+	var namespace string
 
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&capsuleGroup, "capsule-user-group", capsulev1alpha1.GroupVersion.Group, "Name of the group for capsule users")
@@ -96,6 +97,11 @@ func main() {
 	printVersion()
 	if v {
 		os.Exit(0)
+	}
+
+	if namespace = os.Getenv("NAMESPACE"); len(namespace) == 0 {
+		setupLog.Error(fmt.Errorf("unable to determinate the Namespace Capsule is running on"), "unable to start manager")
+		os.Exit(1)
 	}
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
@@ -154,17 +160,19 @@ func main() {
 	}
 
 	if err = (&secret.CaReconciler{
-		Client: mgr.GetClient(),
-		Log:    ctrl.Log.WithName("controllers").WithName("CA"),
-		Scheme: mgr.GetScheme(),
+		Client:    mgr.GetClient(),
+		Log:       ctrl.Log.WithName("controllers").WithName("CA"),
+		Scheme:    mgr.GetScheme(),
+		Namespace: namespace,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Namespace")
 		os.Exit(1)
 	}
 	if err = (&secret.TlsReconciler{
-		Client: mgr.GetClient(),
-		Log:    ctrl.Log.WithName("controllers").WithName("Tls"),
-		Scheme: mgr.GetScheme(),
+		Client:    mgr.GetClient(),
+		Log:       ctrl.Log.WithName("controllers").WithName("Tls"),
+		Scheme:    mgr.GetScheme(),
+		Namespace: namespace,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Namespace")
 		os.Exit(1)


### PR DESCRIPTION
Closes #77.

Just keep in mind that installation is a bit tricky since we're not relying only on Namespace but rather on several other components with the prefix `capsule`: tl;dr; the installation process via `make deploy` is not yet fully supported but I guess this is mandatory [for making this working properly](https://github.com/clastix/capsule-helm-chart/pull/2#issuecomment-686345914)