### PR TITLE
Adding support for RegistryClasses

### DIFF
--- a/api/v1alpha1/registry_class_list.go
+++ b/api/v1alpha1/registry_class_list.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2020 Clastix Labs.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"sort"
+	"strings"
+)
+
+type RegistryList []string
+
+func (n RegistryList) Len() int {
+	return len(n)
+}
+
+func (n RegistryList) Swap(i, j int) {
+	n[i], n[j] = n[j], n[i]
+}
+
+func (n RegistryList) Less(i, j int) bool {
+	return strings.ToLower(n[i]) < strings.ToLower(n[j])
+}
+
+func (n RegistryList) IsStringInList(value string) (ok bool) {
+	sort.Sort(n)
+	i := sort.SearchStrings(n, value)
+	ok = i < n.Len() && n[i] == value
+	return
+}

--- a/api/v1alpha1/tenant_types.go
+++ b/api/v1alpha1/tenant_types.go
@@ -46,15 +46,23 @@ type IngressClassesSpec struct {
 	AllowedRegex string `json:"allowedRegex"`
 }
 
+type RegistryClassesSpec struct {
+	// +nullable
+	Allowed RegistryList `json:"allowed"`
+	// +nullable
+	AllowedRegex string `json:"allowedRegex"`
+}
+
 // TenantSpec defines the desired state of Tenant
 type TenantSpec struct {
 	Owner OwnerSpec `json:"owner"`
 	// +kubebuilder:validation:Optional
 	NamespacesMetadata AdditionalMetadata `json:"namespacesMetadata"`
 	// +kubebuilder:validation:Optional
-	ServicesMetadata AdditionalMetadata `json:"servicesMetadata"`
-	StorageClasses   StorageClassesSpec `json:"storageClasses"`
-	IngressClasses   IngressClassesSpec `json:"ingressClasses"`
+	ServicesMetadata AdditionalMetadata  `json:"servicesMetadata"`
+	StorageClasses   StorageClassesSpec  `json:"storageClasses"`
+	IngressClasses   IngressClassesSpec  `json:"ingressClasses"`
+	RegistryClasses  RegistryClassesSpec `json:"registryClasses"`
 	// +kubebuilder:validation:Optional
 	NodeSelector    map[string]string                `json:"nodeSelector"`
 	NamespaceQuota  NamespaceQuota                   `json:"namespaceQuota"`

--- a/config/crd/bases/capsule.clastix.io_tenants.yaml
+++ b/config/crd/bases/capsule.clastix.io_tenants.yaml
@@ -644,6 +644,20 @@ spec:
               - kind
               - name
               type: object
+            registryClasses:
+              properties:
+                allowed:
+                  items:
+                    type: string
+                  nullable: true
+                  type: array
+                allowedRegex:
+                  nullable: true
+                  type: string
+              required:
+              - allowed
+              - allowedRegex
+              type: object
             resourceQuotas:
               items:
                 description: ResourceQuotaSpec defines the desired hard limits to
@@ -744,6 +758,7 @@ spec:
           - limitRanges
           - namespaceQuota
           - owner
+          - registryClasses
           - storageClasses
           type: object
         status:

--- a/config/samples/capsule_v1alpha1_tenant.yaml
+++ b/config/samples/capsule_v1alpha1_tenant.yaml
@@ -90,3 +90,7 @@ spec:
     allowed:
       - default
     allowedRegex: ""
+  registryClasses:
+    allowed:
+      - default
+    allowedRegex: ""

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -130,6 +130,23 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
+      path: /validating-v1-registry
+  failurePolicy: Fail
+  name: pod.capsule.clastix.io
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - pods
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: webhook-service
+      namespace: system
       path: /validating-v1-tenant
   failurePolicy: Fail
   name: tenant.capsule.clastix.io

--- a/main.go
+++ b/main.go
@@ -43,6 +43,7 @@ import (
 	"github.com/clastix/capsule/pkg/webhook/network_policies"
 	"github.com/clastix/capsule/pkg/webhook/owner_reference"
 	"github.com/clastix/capsule/pkg/webhook/pvc"
+	"github.com/clastix/capsule/pkg/webhook/registry"
 	"github.com/clastix/capsule/pkg/webhook/service_labels"
 	"github.com/clastix/capsule/pkg/webhook/tenant"
 	"github.com/clastix/capsule/pkg/webhook/tenant_prefix"
@@ -146,6 +147,7 @@ func main() {
 		make([]webhook.Webhook, 0),
 		ingress.Webhook(utils.InCapsuleGroup(capsuleGroup, ingress.Handler())),
 		pvc.Webhook(utils.InCapsuleGroup(capsuleGroup, pvc.Handler())),
+		registry.Webhook(utils.InCapsuleGroup(capsuleGroup, registry.Handler())),
 		owner_reference.Webhook(utils.InCapsuleGroup(capsuleGroup, owner_reference.Handler(forceTenantPrefix))),
 		namespace_quota.Webhook(utils.InCapsuleGroup(capsuleGroup, namespace_quota.Handler())),
 		network_policies.Webhook(utils.InCapsuleGroup(capsuleGroup, network_policies.Handler())),

--- a/pkg/webhook/registry/errors.go
+++ b/pkg/webhook/registry/errors.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2020 Clastix Labs.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package registry
+
+import (
+	"fmt"
+)
+
+type registryClassNotValid struct{}
+
+func NewRegistryClassNotValid() error {
+	return &registryClassNotValid{}
+}
+
+func (registryClassNotValid) Error() string {
+	return "A valid Registry Class must be used"
+}
+
+type registryClassForbidden struct {
+	registryClassName string
+}
+
+func NewregistryClassForbidden(registryClassName string) error {
+	return &registryClassForbidden{registryClassName: registryClassName}
+}
+
+func (f registryClassForbidden) Error() string {
+	return fmt.Sprintf("Registry Class %s is forbidden for the current Tenant", f.registryClassName)
+}

--- a/pkg/webhook/registry/validating.go
+++ b/pkg/webhook/registry/validating.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2020 Clastix Labs.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package registry
+
+import (
+	"context"
+	"net/http"
+	"regexp"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	capsulev1alpha1 "github.com/clastix/capsule/api/v1alpha1"
+	capsulewebhook "github.com/clastix/capsule/pkg/webhook"
+)
+
+// +kubebuilder:webhook:path=/validating-v1-registry,mutating=false,failurePolicy=fail,groups="",resources=pods,verbs=create,versions=v1,name=pod.capsule.clastix.io
+
+type webhook struct {
+	handler capsulewebhook.Handler
+}
+
+func Webhook(handler capsulewebhook.Handler) capsulewebhook.Webhook {
+	return &webhook{handler: handler}
+}
+
+func (w *webhook) GetName() string {
+	return "registry"
+}
+
+func (w *webhook) GetPath() string {
+	return "/validating-v1-registry"
+}
+
+func (w *webhook) GetHandler() capsulewebhook.Handler {
+	return w.handler
+}
+
+type handler struct {
+}
+
+func Handler() capsulewebhook.Handler {
+	return &handler{}
+}
+
+func (h *handler) OnCreate(c client.Client, decoder *admission.Decoder) capsulewebhook.Func {
+	return func(ctx context.Context, req admission.Request) admission.Response {
+		var valid, matched bool
+		pod := &v1.Pod{}
+
+		if err := decoder.Decode(req, pod); err != nil {
+			return admission.Errored(http.StatusBadRequest, err)
+		}
+
+		containers := pod.Spec.Containers
+
+		for _, container := range containers {
+			if container.Image == "" {
+				return admission.Errored(http.StatusBadRequest, NewRegistryClassNotValid())
+			}
+		}
+
+		tl := &capsulev1alpha1.TenantList{}
+		if err := c.List(ctx, tl, client.MatchingFieldsSelector{
+			Selector: fields.OneTermEqualSelector(".status.namespaces", pod.Namespace),
+		}); err != nil {
+			return admission.Errored(http.StatusBadRequest, err)
+		}
+
+		if len(tl.Items[0].Spec.RegistryClasses.Allowed) > 0 {
+			for _, container := range containers {
+				valid = tl.Items[0].Spec.RegistryClasses.Allowed.IsStringInList(container.Image)
+			}
+		}
+
+		if len(tl.Items[0].Spec.RegistryClasses.Allowed) > 0 {
+			for _, container := range containers {
+				matched, _ = regexp.MatchString(tl.Items[0].Spec.RegistryClasses.AllowedRegex, container.Image)
+			}
+		}
+
+		if !valid && !matched {
+			for _, container := range containers {
+				return admission.Errored(http.StatusBadRequest, NewregistryClassForbidden(container.Image))
+			}
+		}
+		return admission.Allowed("")
+
+	}
+}
+
+func (h *handler) OnDelete(client client.Client, decoder *admission.Decoder) capsulewebhook.Func {
+	return func(ctx context.Context, req admission.Request) admission.Response {
+		return admission.Allowed("")
+	}
+}
+
+func (h *handler) OnUpdate(client client.Client, decoder *admission.Decoder) capsulewebhook.Func {
+	return func(ctx context.Context, req admission.Request) admission.Response {
+		return admission.Allowed("")
+	}
+}


### PR DESCRIPTION
Fixes #1. 

Will allow running declared container images from the specified registries defined in the _Tenant_ spec.
