### PR TITLE
Allowing dash on Tenant namespace

### DIFF
--- a/e2e/custom_capsule_group_test.go
+++ b/e2e/custom_capsule_group_test.go
@@ -32,7 +32,7 @@ import (
 var _ = Describe("creating a Namespace as Tenant owner with custom --capsule-group", func() {
 	tnt := &v1alpha1.Tenant{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "tenantassignedcustomgroup",
+			Name: "tenant-assigned-custom-group",
 		},
 		Spec: v1alpha1.TenantSpec{
 			Owner: v1alpha1.OwnerSpec{

--- a/e2e/ingress_class_test.go
+++ b/e2e/ingress_class_test.go
@@ -33,7 +33,7 @@ import (
 var _ = Describe("when Tenant handles Ingress classes", func() {
 	tnt := &v1alpha1.Tenant{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "ingressclass",
+			Name: "ingress-class",
 		},
 		Spec: v1alpha1.TenantSpec{
 			Owner: v1alpha1.OwnerSpec{

--- a/e2e/namespace_metadata_test.go
+++ b/e2e/namespace_metadata_test.go
@@ -33,7 +33,7 @@ import (
 var _ = Describe("creating a Namespace for a Tenant with additional metadata", func() {
 	tnt := &v1alpha1.Tenant{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "tenantmetadata",
+			Name: "tenant-metadata",
 		},
 		Spec: v1alpha1.TenantSpec{
 			Owner: v1alpha1.OwnerSpec{

--- a/e2e/new_namespace_test.go
+++ b/e2e/new_namespace_test.go
@@ -32,7 +32,7 @@ import (
 var _ = Describe("creating a Namespace as Tenant owner", func() {
 	tnt := &v1alpha1.Tenant{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "tenantassigned",
+			Name: "tenant-assigned",
 		},
 		Spec: v1alpha1.TenantSpec{
 			Owner: v1alpha1.OwnerSpec{

--- a/e2e/overquota_namespace_test.go
+++ b/e2e/overquota_namespace_test.go
@@ -32,7 +32,7 @@ import (
 var _ = Describe("creating a Namespace over-quota", func() {
 	tnt := &v1alpha1.Tenant{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "overquotatenant",
+			Name: "over-quota-tenant",
 		},
 		Spec: v1alpha1.TenantSpec{
 			Owner: v1alpha1.OwnerSpec{

--- a/e2e/owner_webhooks_test.go
+++ b/e2e/owner_webhooks_test.go
@@ -36,7 +36,7 @@ import (
 var _ = Describe("when Tenant owner interacts with the webhooks", func() {
 	tnt := &v1alpha1.Tenant{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "tenantowner",
+			Name: "tenant-owner",
 		},
 		Spec: v1alpha1.TenantSpec{
 			Owner: v1alpha1.OwnerSpec{

--- a/e2e/protected_namespace_regex_test.go
+++ b/e2e/protected_namespace_regex_test.go
@@ -32,7 +32,7 @@ import (
 var _ = Describe("creating a Namespace with --protected-namespace-regex enabled", func() {
 	tnt := &v1alpha1.Tenant{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "tenantprotectednamespace",
+			Name: "tenant-protected-namespace",
 		},
 		Spec: v1alpha1.TenantSpec{
 			Owner: v1alpha1.OwnerSpec{

--- a/e2e/resource_quota_exceeded_test.go
+++ b/e2e/resource_quota_exceeded_test.go
@@ -39,7 +39,7 @@ import (
 var _ = Describe("exceeding Tenant resource quota", func() {
 	tnt := &v1alpha1.Tenant{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "tenantresourceschanges",
+			Name: "tenant-resources-changes",
 		},
 		Spec: v1alpha1.TenantSpec{
 			Owner: v1alpha1.OwnerSpec{

--- a/e2e/selecting_non_owned_tenant_test.go
+++ b/e2e/selecting_non_owned_tenant_test.go
@@ -32,7 +32,7 @@ import (
 var _ = Describe("creating a Namespace trying to select a third Tenant", func() {
 	tnt := &v1alpha1.Tenant{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "tenantnonowned",
+			Name: "tenant-non-owned",
 		},
 		Spec: v1alpha1.TenantSpec{
 			Owner: v1alpha1.OwnerSpec{

--- a/e2e/selecting_tenant_fail_test.go
+++ b/e2e/selecting_tenant_fail_test.go
@@ -32,7 +32,7 @@ import (
 var _ = Describe("creating a Namespace without a Tenant selector when user owns multiple Tenants", func() {
 	t1 := &v1alpha1.Tenant{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "tenantone",
+			Name: "tenant-one",
 		},
 		Spec: v1alpha1.TenantSpec{
 			Owner: v1alpha1.OwnerSpec{
@@ -51,7 +51,7 @@ var _ = Describe("creating a Namespace without a Tenant selector when user owns 
 	}
 	t2 := &v1alpha1.Tenant{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "tenanttwo",
+			Name: "tenant-two",
 		},
 		Spec: v1alpha1.TenantSpec{
 			Owner: v1alpha1.OwnerSpec{
@@ -70,7 +70,7 @@ var _ = Describe("creating a Namespace without a Tenant selector when user owns 
 	}
 	t3 := &v1alpha1.Tenant{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "tenantthree",
+			Name: "tenant-three",
 		},
 		Spec: v1alpha1.TenantSpec{
 			Owner: v1alpha1.OwnerSpec{
@@ -89,7 +89,7 @@ var _ = Describe("creating a Namespace without a Tenant selector when user owns 
 	}
 	t4 := &v1alpha1.Tenant{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "tenantfour",
+			Name: "tenant-four",
 		},
 		Spec: v1alpha1.TenantSpec{
 			Owner: v1alpha1.OwnerSpec{

--- a/e2e/selecting_tenant_with_label_test.go
+++ b/e2e/selecting_tenant_with_label_test.go
@@ -32,7 +32,7 @@ import (
 var _ = Describe("creating a Namespace with Tenant selector when user owns multiple tenants", func() {
 	t1 := &v1alpha1.Tenant{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "tenantone",
+			Name: "tenant-one",
 		},
 		Spec: v1alpha1.TenantSpec{
 			Owner: v1alpha1.OwnerSpec{
@@ -51,7 +51,7 @@ var _ = Describe("creating a Namespace with Tenant selector when user owns multi
 	}
 	t2 := &v1alpha1.Tenant{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "tenanttwo",
+			Name: "tenant-two",
 		},
 		Spec: v1alpha1.TenantSpec{
 			Owner: v1alpha1.OwnerSpec{

--- a/e2e/service_metadata_test.go
+++ b/e2e/service_metadata_test.go
@@ -34,7 +34,7 @@ import (
 var _ = Describe("creating a Service/Endpoint/EndpointSlice for a Tenant with additional metadata", func() {
 	tnt := &v1alpha1.Tenant{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "servicemetadata",
+			Name: "service-metadata",
 		},
 		Spec: v1alpha1.TenantSpec{
 			Owner: v1alpha1.OwnerSpec{

--- a/e2e/storage_class_test.go
+++ b/e2e/storage_class_test.go
@@ -32,7 +32,7 @@ import (
 var _ = Describe("when Tenant handles Storage classes", func() {
 	tnt := &v1alpha1.Tenant{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "storageclass",
+			Name: "storage-class",
 		},
 		Spec: v1alpha1.TenantSpec{
 			Owner: v1alpha1.OwnerSpec{

--- a/e2e/tenant_name_webhook_test.go
+++ b/e2e/tenant_name_webhook_test.go
@@ -32,7 +32,7 @@ import (
 var _ = Describe("creating a Tenant with wrong name", func() {
 	tnt := &v1alpha1.Tenant{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "wrong-name",
+			Name: "non_rfc_dns_1123",
 		},
 		Spec: v1alpha1.TenantSpec{
 			Owner: v1alpha1.OwnerSpec{

--- a/e2e/tenant_owner_group_test.go
+++ b/e2e/tenant_owner_group_test.go
@@ -32,7 +32,7 @@ import (
 var _ = Describe("creating a Namespace with group Tenant owner", func() {
 	tnt := &v1alpha1.Tenant{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "tenantgroupowner",
+			Name: "tenant-group-owner",
 		},
 		Spec: v1alpha1.TenantSpec{
 			Owner: v1alpha1.OwnerSpec{

--- a/e2e/tenant_resources_changes_test.go
+++ b/e2e/tenant_resources_changes_test.go
@@ -37,7 +37,7 @@ import (
 var _ = Describe("changing Tenant managed Kubernetes resources", func() {
 	tnt := &v1alpha1.Tenant{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "tenantresourceschanges",
+			Name: "tenant-resources-changes",
 		},
 		Spec: v1alpha1.TenantSpec{
 			Owner: v1alpha1.OwnerSpec{

--- a/e2e/tenant_resources_test.go
+++ b/e2e/tenant_resources_test.go
@@ -38,7 +38,7 @@ import (
 var _ = Describe("creating namespaces within a Tenant with resources", func() {
 	tnt := &v1alpha1.Tenant{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "tenantresources",
+			Name: "tenant-resources",
 		},
 		Spec: v1alpha1.TenantSpec{
 			Owner: v1alpha1.OwnerSpec{

--- a/pkg/webhook/tenant/validating.go
+++ b/pkg/webhook/tenant/validating.go
@@ -64,7 +64,7 @@ func (r *handler) OnCreate(client client.Client, decoder *admission.Decoder) cap
 			return admission.Errored(http.StatusBadRequest, err)
 		}
 
-		matched, _ := regexp.MatchString(`^[a-z0-9]([a-z0-9]*[a-z0-9])?$`, tnt.GetName())
+		matched, _ := regexp.MatchString(`[a-z0-9]([-a-z0-9]*[a-z0-9])?`, tnt.GetName())
 		if !matched {
 			return admission.Denied("Tenant name has forbidden characters")
 		}


### PR DESCRIPTION
This is an improvement started from the discussion on #113 and addressing also #106.

We would like to be less strict regarding Tenant naming, allowing end-users to use dashes according to [DNS RFC-1123](https://tools.ietf.org/html/rfc1123), the same applied by Kubernetes for some resources.

I'd like to get a review from @MaxFedotov since he was the author of the force tenant prefix.