### PR TITLE
Providing additional print column for the nodeSelector Tenant spec

### DIFF
--- a/api/v1alpha1/tenant_types.go
+++ b/api/v1alpha1/tenant_types.go
@@ -100,6 +100,7 @@ type TenantStatus struct {
 // +kubebuilder:printcolumn:name="Namespace count",type="integer",JSONPath=".status.size",description="The total amount of Namespaces in use"
 // +kubebuilder:printcolumn:name="Owner name",type="string",JSONPath=".spec.owner.name",description="The assigned Tenant owner"
 // +kubebuilder:printcolumn:name="Owner kind",type="string",JSONPath=".spec.owner.kind",description="The assigned Tenant owner kind"
+// +kubebuilder:printcolumn:name="Node selector",type="string",JSONPath=".spec.nodeSelector",description="Node Selector applied to Pods"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Age"
 
 // Tenant is the Schema for the tenants API

--- a/config/crd/bases/capsule.clastix.io_tenants.yaml
+++ b/config/crd/bases/capsule.clastix.io_tenants.yaml
@@ -25,6 +25,10 @@ spec:
     description: The assigned Tenant owner kind
     name: Owner kind
     type: string
+  - JSONPath: .spec.nodeSelector
+    description: Node Selector applied to Pods
+    name: Node selector
+    type: string
   - JSONPath: .metadata.creationTimestamp
     description: Age
     name: Age


### PR DESCRIPTION
Closes #137.

The output differs from the one requested on the issue due to the underlying library we're using:

```
# kubectl get tenants.capsule.clastix.io -o wide
NAME   NAMESPACE QUOTA   NAMESPACE COUNT   OWNER NAME   OWNER KIND   NODE SELECTOR                  AGE
oil    3                 0                 alice        User         {"kubernetes.io/os":"linux"}   1s
```