### PR TITLE
Logging timestamp to ISO 8601

### DIFF
--- a/main.go
+++ b/main.go
@@ -23,11 +23,11 @@ import (
 	"regexp"
 	goRuntime "runtime"
 
+	"go.uber.org/zap/zapcore"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
-
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -90,8 +90,12 @@ func main() {
 		"during Namespace creation, to name it using the selected Tenant name as prefix, separated by a dash. "+
 		"This is useful to avoid Namespace name collision in a public CaaS environment.")
 	flag.StringVar(&protectedNamespaceRegexpString, "protected-namespace-regex", "", "Disallow creation of namespaces, whose name matches this regexp")
-	opts := zap.Options{}
 
+	opts := zap.Options{
+		EncoderConfigOptions: append([]zap.EncoderConfigOption{}, func(config *zapcore.EncoderConfig) {
+			config.EncodeTime = zapcore.ISO8601TimeEncoder
+		}),
+	}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
 


### PR DESCRIPTION
Closes #139.

JSON output of logs:

```json
{"level":"info","ts":"2020-11-17T20:05:23.974+0100","logger":"setup","msg":"Capsule Version dev dirty"}
{"level":"info","ts":"2020-11-17T20:05:23.974+0100","logger":"setup","msg":"Build from: "}
{"level":"info","ts":"2020-11-17T20:05:23.974+0100","logger":"setup","msg":"Build date: "}
{"level":"info","ts":"2020-11-17T20:05:23.974+0100","logger":"setup","msg":"Go Version: go1.13.8"}
{"level":"info","ts":"2020-11-17T20:05:23.974+0100","logger":"setup","msg":"Go OS/Arch: linux/amd64"}
```

We can switch to `RFC3339` or `RFC3339Nano` as well, but I guess ISO is a nice standard, don't you think so @MaxFedotov?