### PR TITLE
Debugging GitHub action

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,7 +139,6 @@ e2e/%:
 	kind create cluster --name capsule --image=kindest/node:$*
 	make docker-build
 	kind load docker-image --nodes capsule-control-plane --name capsule $(IMG)
-	kubectl create namespace capsule-system
-	helm upgrade --install --namespace capsule-system capsule ./charts/capsule --set 'manager.image.pullPolicy=Never' --set 'manager.resources=null'
+	helm upgrade --debug --install --namespace capsule-system --create-namespace capsule ./charts/capsule --set 'manager.image.pullPolicy=Never' --set 'manager.resources=null' --set "manager.image.tag=$(VERSION)"
 	ginkgo -v -tags e2e ./e2e
 	kind delete cluster --name capsule


### PR DESCRIPTION
This issue happened due to the release of a release candidate not tracked into the Helm chart.

Our e2e test suite is using the local Chart that is version pinned to the latest stable release and, due to `Never` pull image policy, the Capsule manager Pod wasn't able to create the CA and TLS certificate, timing out.