### PR TITLE
Allowing multiple Tenant resources to share same exact list of allowed hostnames

### DIFF
--- a/charts/capsule/Chart.yaml
+++ b/charts/capsule/Chart.yaml
@@ -21,7 +21,7 @@ sources:
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.0.16
+version: 0.0.17
 
 # This is the version number of the application being deployed.
 # This version number should be incremented each time you make changes to the application.

--- a/charts/capsule/README.md
+++ b/charts/capsule/README.md
@@ -65,6 +65,7 @@ Parameter | Description | Default
 `manager.options.capsuleUserGroup` | Override the Capsule user group | `capsule.clastix.io`
 `manager.options.protectedNamespaceRegex` | If specified, disallows creation of namespaces matching the passed regexp | `null`
 `manager.options.allowIngressHostnameCollision` | Allow the Ingress hostname collision at Ingress resource level across all the Tenants | `true`
+`manager.options.allowTenantIngressHostnamesCollision` | Skip the validation check at Tenant level for colliding Ingress hostnames | `false`
 `manager.image.repository` | Set the image repository of the controller. | `quay.io/clastix/capsule`
 `manager.image.tag` | Overrides the image tag whose default is the chart. `appVersion` | `null`
 `manager.image.pullPolicy` | Set the image pull policy. | `IfNotPresent`

--- a/charts/capsule/templates/deployment.yaml
+++ b/charts/capsule/templates/deployment.yaml
@@ -53,6 +53,7 @@ spec:
           {{ if .Values.manager.options.capsuleUserGroup }}- --capsule-user-group={{ .Values.manager.options.capsuleUserGroup }}{{ end }}
           {{ if .Values.manager.options.protectedNamespaceRegex }}- --protected-namespace-regex={{ .Values.manager.options.protectedNamespaceRegex }}{{ end }}
           - --allow-ingress-hostname-collision={{ .Values.manager.options.allowIngressHostnameCollision | default "true" }}
+          - --allow-tenant-ingress-hostnames-collision={{ .Values.manager.allowTenantIngressHostnamesCollision | default "false" }}
           image: {{ include "capsule.managerFullyQualifiedDockerImage" . }}
           imagePullPolicy: {{ .Values.manager.image.pullPolicy }}
           env:

--- a/charts/capsule/values.yaml
+++ b/charts/capsule/values.yaml
@@ -14,6 +14,7 @@ manager:
     capsuleUserGroup:
     protectedNamespaceRegex:
     allowIngressHostnameCollision:
+    allowTenantIngressHostnamesCollision:
   livenessProbe:
     httpGet:
       path: /healthz
@@ -22,6 +23,7 @@ manager:
     httpGet:
       path: /readyz
       port: 10080
+
   resources:
     limits:
       cpu: 200m

--- a/docs/operator/references.md
+++ b/docs/operator/references.md
@@ -677,6 +677,7 @@ Option | Description | Default
 `--capsule-user-group` | Override the Capsule group to which all tenant owners must belong. | `capsule.clastix.io`
 `--protected-namespace-regex` | Disallows creation of namespaces matching the passed regexp. | `null`
 `--allow-ingress-hostname-collision` | By default, Capsule allows Ingress hostname collision: set to `false` to enforce this policy. | `true`
+`--allow-tenant-ingress-hostnames-collision` | Toggling this, Capsule will not check if a hostname collision is in place, allowing the creation of two or more Tenant resources although sharing the same allowed hostname(s). | `false`
 
 ## Created Resources
 Once installed, the Capsule operator creates the following resources in your cluster:

--- a/e2e/tenant_ingress_hostnames_collision_blocked_test.go
+++ b/e2e/tenant_ingress_hostnames_collision_blocked_test.go
@@ -1,0 +1,79 @@
+//+build e2e
+
+/*
+Copyright 2020 Clastix Labs.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/clastix/capsule/api/v1alpha1"
+)
+
+var _ = Describe("when a second Tenant contains an already declared allowed Ingress hostname", func() {
+	tnt := &v1alpha1.Tenant{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "no-collision-ingress-hostnames",
+		},
+		Spec: v1alpha1.TenantSpec{
+			Owner: v1alpha1.OwnerSpec{
+				Name: "first-user",
+				Kind: "User",
+			},
+			IngressHostnames: &v1alpha1.AllowedListSpec{
+				Exact: []string{"capsule.clastix.io", "docs.capsule.k8s", "42.clatix.io"},
+			},
+		},
+	}
+
+	JustBeforeEach(func() {
+		EventuallyCreation(func() error {
+			tnt.ResourceVersion = ""
+			return k8sClient.Create(context.TODO(), tnt)
+		}).Should(Succeed())
+	})
+	JustAfterEach(func() {
+		Expect(k8sClient.Delete(context.TODO(), tnt)).Should(Succeed())
+	})
+
+	It("should block creation if contains collided Ingress hostnames", func() {
+		for i, h := range tnt.Spec.IngressHostnames.Exact {
+			tnt2 := &v1alpha1.Tenant{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: fmt.Sprintf("%s-%d", tnt.GetName(), i),
+				},
+				Spec: v1alpha1.TenantSpec{
+					Owner: v1alpha1.OwnerSpec{
+						Name: "second-user",
+						Kind: "User",
+					},
+					IngressHostnames: &v1alpha1.AllowedListSpec{
+						Exact: []string{h},
+					},
+				},
+			}
+			EventuallyCreation(func() error {
+				return k8sClient.Create(context.TODO(), tnt2)
+			}).ShouldNot(Succeed())
+		}
+	})
+})

--- a/pkg/webhook/tenant/validating.go
+++ b/pkg/webhook/tenant/validating.go
@@ -52,10 +52,11 @@ func (w webhook) GetHandler() capsulewebhook.Handler {
 }
 
 type handler struct {
+	checkIngressHostnamesExact bool
 }
 
-func Handler() capsulewebhook.Handler {
-	return &handler{}
+func Handler(allowTenantIngressHostnamesCollision bool) capsulewebhook.Handler {
+	return &handler{checkIngressHostnamesExact: !allowTenantIngressHostnamesCollision}
 }
 
 // Validate Tenant name
@@ -109,7 +110,7 @@ func (h *handler) validateIngressHostnamesRegex(tenant *v1alpha1.Tenant) error {
 
 // Check Ingress hostnames collision across all available Tenants
 func (h *handler) validateIngressHostnamesCollision(context context.Context, clt client.Client, tenant *v1alpha1.Tenant) error {
-	if tenant.Spec.IngressHostnames != nil && len(tenant.Spec.IngressHostnames.Exact) > 0 {
+	if h.checkIngressHostnamesExact && tenant.Spec.IngressHostnames != nil && len(tenant.Spec.IngressHostnames.Exact) > 0 {
 		for _, h := range tenant.Spec.IngressHostnames.Exact {
 			tl := &v1alpha1.TenantList{}
 			if err := clt.List(context, tl, client.MatchingFieldsSelector{


### PR DESCRIPTION
Closes #206.

Editing the original message due to some mess during PRs.

A new CLI flag (`--allow-tenant-ingress-hostnames-collision`) is added, defaulted to `false` to preserve backward compatibility: in case of toggling, Capsule will skip the Tenant validation that checks for hostnames collision in the key `Spec.ingressHostnames.allowed`.

I summon @bsctl: we need your super QA powers, here!