### PR TITLE
Ingress hostname collision

### DIFF
--- a/charts/capsule/Chart.yaml
+++ b/charts/capsule/Chart.yaml
@@ -21,7 +21,7 @@ sources:
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.0.12
+version: 0.0.13
 
 # This is the version number of the application being deployed.
 # This version number should be incremented each time you make changes to the application.

--- a/charts/capsule/README.md
+++ b/charts/capsule/README.md
@@ -64,6 +64,7 @@ Parameter | Description | Default
 `manager.options.forceTenantPrefix` | Boolean, enforces the Tenant owner, during Namespace creation, to name it using the selected Tenant name as prefix, separated by a dash | `false`
 `manager.options.capsuleUserGroup` | Override the Capsule user group | `capsule.clastix.io`
 `manager.options.protectedNamespaceRegex` | If specified, disallows creation of namespaces matching the passed regexp | `null`
+`manager.options.allowIngressHostnameCollision` | Allow the Ingress hostname collision at Ingress resource level across all the Tenants | `true`
 `manager.image.repository` | Set the image repository of the controller. | `quay.io/clastix/capsule`
 `manager.image.tag` | Overrides the image tag whose default is the chart. `appVersion` | `null`
 `manager.image.pullPolicy` | Set the image pull policy. | `IfNotPresent`

--- a/charts/capsule/templates/deployment.yaml
+++ b/charts/capsule/templates/deployment.yaml
@@ -52,6 +52,7 @@ spec:
           {{ if .Values.manager.options.forceTenantPrefix }}- --force-tenant-prefix={{ .Values.manager.options.forceTenantPrefix }}{{ end }}
           {{ if .Values.manager.options.capsuleUserGroup }}- --capsule-user-group={{ .Values.manager.options.capsuleUserGroup }}{{ end }}
           {{ if .Values.manager.options.protectedNamespaceRegex }}- --protected-namespace-regex={{ .Values.manager.options.protectedNamespaceRegex }}{{ end }}
+          - --allow-ingress-hostname-collision={{ .Values.manager.options.allowIngressHostnameCollision | default "true" }}
           image: {{ include "capsule.managerFullyQualifiedDockerImage" . }}
           imagePullPolicy: {{ .Values.manager.image.pullPolicy }}
           env:

--- a/charts/capsule/values.yaml
+++ b/charts/capsule/values.yaml
@@ -13,6 +13,7 @@ manager:
     forceTenantPrefix:
     capsuleUserGroup:
     protectedNamespaceRegex:
+    allowIngressHostnameCollision:
   resources:
     limits:
       cpu: 200m

--- a/docs/operator/references.md
+++ b/docs/operator/references.md
@@ -676,6 +676,7 @@ Option | Description | Default
 `--zap-devel` | The flag to get the stack traces for deep debugging.  | `null`
 `--capsule-user-group` | Override the Capsule group to which all tenant owners must belong. | `capsule.clastix.io`
 `--protected-namespace-regex` | Disallows creation of namespaces matching the passed regexp. | `null`
+`--allow-ingress-hostname-collision` | By default, Capsule allows Ingress hostname collision: set to `false` to enforce this policy. | `true`
 
 ## Created Resources
 Once installed, the Capsule operator creates the following resources in your cluster:

--- a/e2e/ingress_hostnames_allowed_collision_test.go
+++ b/e2e/ingress_hostnames_allowed_collision_test.go
@@ -1,0 +1,127 @@
+//+build e2e
+
+/*
+Copyright 2020 Clastix Labs.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/clastix/capsule/api/v1alpha1"
+)
+
+var _ = Describe("when handling Ingress hostnames collision", func() {
+	tnt := &v1alpha1.Tenant{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "ingress-hostnames-allowed-collision",
+		},
+		Spec: v1alpha1.TenantSpec{
+			Owner: v1alpha1.OwnerSpec{
+				Name: "ingress-allowed",
+				Kind: "User",
+			},
+		},
+	}
+
+	// scaffold a basic networking.k8s.io Ingress with name and host
+	networkingIngress := func(name, hostname string) *networkingv1.Ingress {
+		return &networkingv1.Ingress{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+			},
+			Spec: networkingv1.IngressSpec{
+				Rules: []networkingv1.IngressRule{
+					{
+						Host: hostname,
+					},
+				},
+			},
+		}
+	}
+	// scaffold a basic extensions Ingress with name and host
+	extensionsIngress := func(name, hostname string) *extensionsv1beta1.Ingress {
+		return &extensionsv1beta1.Ingress{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+			},
+			Spec: extensionsv1beta1.IngressSpec{
+				Rules: []extensionsv1beta1.IngressRule{
+					{
+						Host: hostname,
+					},
+				},
+			},
+		}
+
+	}
+
+	JustBeforeEach(func() {
+		EventuallyCreation(func() error {
+			tnt.ResourceVersion = ""
+			return k8sClient.Create(context.TODO(), tnt)
+		}).Should(Succeed())
+	})
+	JustAfterEach(func() {
+		Expect(k8sClient.Delete(context.TODO(), tnt)).Should(Succeed())
+	})
+
+	It("should allow creating several Ingress with same hostname", func() {
+		maj, min, _ := GetKubernetesSemVer()
+
+		ns := NewNamespace("allowed-collision")
+		cs := ownerClient(tnt)
+
+		NamespaceCreation(ns, tnt, defaultTimeoutInterval).Should(Succeed())
+		TenantNamespaceList(tnt, podRecreationTimeoutInterval).Should(ContainElement(ns.GetName()))
+
+		if maj == 1 && min > 18 {
+			By("testing networking.k8s.io", func() {
+				Eventually(func() (err error) {
+					obj := networkingIngress("networking-1", "kubernetes.io")
+					_, err = cs.NetworkingV1().Ingresses(ns.GetName()).Create(context.TODO(), obj, metav1.CreateOptions{})
+					return
+				}, defaultTimeoutInterval, defaultPollInterval).Should(Succeed())
+				Eventually(func() (err error) {
+					obj := networkingIngress("networking-2", "kubernetes.io")
+					_, err = cs.NetworkingV1().Ingresses(ns.GetName()).Create(context.TODO(), obj, metav1.CreateOptions{})
+					return
+				}, defaultTimeoutInterval, defaultPollInterval).Should(Succeed())
+			})
+		}
+
+		if maj == 1 && min < 22 {
+			By("testing extensions", func() {
+				Eventually(func() (err error) {
+					obj := extensionsIngress("extensions-1", "kubernetes.io")
+					_, err = cs.ExtensionsV1beta1().Ingresses(ns.GetName()).Create(context.TODO(), obj, metav1.CreateOptions{})
+					return
+				}, defaultTimeoutInterval, defaultPollInterval).Should(Succeed())
+				Eventually(func() (err error) {
+					obj := extensionsIngress("extensions-2", "kubernetes.io")
+					_, err = cs.ExtensionsV1beta1().Ingresses(ns.GetName()).Create(context.TODO(), obj, metav1.CreateOptions{})
+					return
+				}, defaultTimeoutInterval, defaultPollInterval).Should(Succeed())
+			})
+		}
+	})
+})

--- a/e2e/ingress_hostnames_denied_collision_test.go
+++ b/e2e/ingress_hostnames_denied_collision_test.go
@@ -1,0 +1,128 @@
+//+build e2e
+
+/*
+Copyright 2020 Clastix Labs.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/clastix/capsule/api/v1alpha1"
+)
+
+var _ = Describe("when handling Ingress hostnames collision", func() {
+	tnt := &v1alpha1.Tenant{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "ingress-hostnames-denied-collision",
+		},
+		Spec: v1alpha1.TenantSpec{
+			Owner: v1alpha1.OwnerSpec{
+				Name: "ingress-denied",
+				Kind: "User",
+			},
+		},
+	}
+
+	// scaffold a basic networking.k8s.io Ingress with name and host
+	networkingIngress := func(name, hostname string) *networkingv1.Ingress {
+		return &networkingv1.Ingress{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+			},
+			Spec: networkingv1.IngressSpec{
+				Rules: []networkingv1.IngressRule{
+					{
+						Host: hostname,
+					},
+				},
+			},
+		}
+	}
+	// scaffold a basic extensions Ingress with name and host
+	extensionsIngress := func(name, hostname string) *extensionsv1beta1.Ingress {
+		return &extensionsv1beta1.Ingress{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+			},
+			Spec: extensionsv1beta1.IngressSpec{
+				Rules: []extensionsv1beta1.IngressRule{
+					{
+						Host: hostname,
+					},
+				},
+			},
+		}
+
+	}
+
+	JustBeforeEach(func() {
+		EventuallyCreation(func() error {
+			return k8sClient.Create(context.TODO(), tnt)
+		}).Should(Succeed())
+		ModifyCapsuleManagerPodArgs(append(defaulManagerPodArgs, []string{"--allow-ingress-hostname-collision=false"}...))
+	})
+	JustAfterEach(func() {
+		Expect(k8sClient.Delete(context.TODO(), tnt)).Should(Succeed())
+		ModifyCapsuleManagerPodArgs(defaulManagerPodArgs)
+	})
+
+	It("should not allow creating several Ingress with same hostname", func() {
+		maj, min, _ := GetKubernetesSemVer()
+
+		ns := NewNamespace("allowed-collision")
+		cs := ownerClient(tnt)
+
+		NamespaceCreation(ns, tnt, defaultTimeoutInterval).Should(Succeed())
+		TenantNamespaceList(tnt, podRecreationTimeoutInterval).Should(ContainElement(ns.GetName()))
+
+		if maj == 1 && min > 18 {
+			By("testing networking.k8s.io", func() {
+				Eventually(func() (err error) {
+					obj := networkingIngress("networking-1", "kubernetes.io")
+					_, err = cs.NetworkingV1().Ingresses(ns.GetName()).Create(context.TODO(), obj, metav1.CreateOptions{})
+					return
+				}, defaultTimeoutInterval, defaultPollInterval).Should(Succeed())
+				Eventually(func() (err error) {
+					obj := networkingIngress("networking-2", "kubernetes.io")
+					_, err = cs.NetworkingV1().Ingresses(ns.GetName()).Create(context.TODO(), obj, metav1.CreateOptions{})
+					return
+				}, defaultTimeoutInterval, defaultPollInterval).ShouldNot(Succeed())
+			})
+		}
+
+		if maj == 1 && min < 22 {
+			By("testing extensions", func() {
+				Eventually(func() (err error) {
+					obj := extensionsIngress("extensions-1", "cncf.io")
+					_, err = cs.ExtensionsV1beta1().Ingresses(ns.GetName()).Create(context.TODO(), obj, metav1.CreateOptions{})
+					return
+				}, defaultTimeoutInterval, defaultPollInterval).Should(Succeed())
+				Eventually(func() (err error) {
+					obj := extensionsIngress("extensions-2", "cncf.io")
+					_, err = cs.ExtensionsV1beta1().Ingresses(ns.GetName()).Create(context.TODO(), obj, metav1.CreateOptions{})
+					return
+				}, defaultTimeoutInterval, defaultPollInterval).ShouldNot(Succeed())
+			})
+		}
+	})
+})

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.0
 	github.com/onsi/ginkgo v1.14.1
 	github.com/onsi/gomega v1.10.2
+	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.5.1
 	go.uber.org/zap v1.15.0
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e

--- a/main.go
+++ b/main.go
@@ -80,6 +80,7 @@ func main() {
 	var capsuleGroup string
 	var protectedNamespaceRegexpString string
 	var protectedNamespaceRegexp *regexp.Regexp
+	var allowIngressHostnamesCollision bool
 	var namespace string
 
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
@@ -92,6 +93,7 @@ func main() {
 		"during Namespace creation, to name it using the selected Tenant name as prefix, separated by a dash. "+
 		"This is useful to avoid Namespace name collision in a public CaaS environment.")
 	flag.StringVar(&protectedNamespaceRegexpString, "protected-namespace-regex", "", "Disallow creation of namespaces, whose name matches this regexp")
+	flag.BoolVar(&allowIngressHostnamesCollision, "allow-ingress-hostname-collision", true, "Allow the Ingress hostname collision at Ingress resource level across all the Tenants.")
 
 	opts := zap.Options{
 		EncoderConfigOptions: append([]zap.EncoderConfigOption{}, func(config *zapcore.EncoderConfig) {
@@ -157,7 +159,7 @@ func main() {
 	// webhooks: the order matters, don't change it and just append
 	wl := append(
 		make([]webhook.Webhook, 0),
-		ingress.Webhook(ingress.Handler()),
+		ingress.Webhook(ingress.Handler(allowIngressHostnamesCollision)),
 		pvc.Webhook(pvc.Handler()),
 		registry.Webhook(registry.Handler()),
 		services.Webhook(services.Handler()),

--- a/pkg/indexer/add_ingress.go
+++ b/pkg/indexer/add_ingress.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2020 Clastix Labs.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package indexer
+
+import (
+	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
+	networkingv1beta1 "k8s.io/api/networking/v1beta1"
+
+	"github.com/clastix/capsule/pkg/indexer/ingress"
+)
+
+func init() {
+	AddToIndexerFuncs = append(AddToIndexerFuncs, ingress.Hostname{Obj: &extensionsv1beta1.Ingress{}})
+	AddToIndexerFuncs = append(AddToIndexerFuncs, ingress.Hostname{Obj: &networkingv1.Ingress{}})
+	AddToIndexerFuncs = append(AddToIndexerFuncs, ingress.Hostname{Obj: &networkingv1beta1.Ingress{}})
+}

--- a/pkg/indexer/ingress/hostname.go
+++ b/pkg/indexer/ingress/hostname.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2020 Clastix Labs.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ingress
+
+import (
+	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
+	networkingv1beta1 "k8s.io/api/networking/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type Hostname struct {
+	Obj metav1.Object
+}
+
+func (h Hostname) Object() client.Object {
+	return h.Obj.(client.Object)
+}
+
+func (h Hostname) Field() string {
+	return ".spec.rules[*].host"
+}
+
+func (h Hostname) Func() client.IndexerFunc {
+	return func(object client.Object) (hostnames []string) {
+		switch h.Obj.(type) {
+		case *networkingv1.Ingress:
+			ing := object.(*networkingv1.Ingress)
+			for _, r := range ing.Spec.Rules {
+				hostnames = append(hostnames, r.Host)
+			}
+			return
+		case *networkingv1beta1.Ingress:
+			ing := object.(*networkingv1beta1.Ingress)
+			for _, r := range ing.Spec.Rules {
+				hostnames = append(hostnames, r.Host)
+			}
+			return
+		case *extensionsv1beta1.Ingress:
+			ing := object.(*extensionsv1beta1.Ingress)
+			for _, r := range ing.Spec.Rules {
+				hostnames = append(hostnames, r.Host)
+			}
+			return
+		default:
+			return
+		}
+	}
+}

--- a/pkg/webhook/ingress/errors.go
+++ b/pkg/webhook/ingress/errors.go
@@ -45,6 +45,18 @@ type ingressHostnameNotValid struct {
 	spec                 v1alpha1.AllowedListSpec
 }
 
+type ingressHostnameCollision struct {
+	hostname string
+}
+
+func (i ingressHostnameCollision) Error() string {
+	return fmt.Sprintf("hostname %s is already used across the cluster: please, reach out to the system administrators", i.hostname)
+}
+
+func NewIngressHostnameCollision(hostname string) error {
+	return ingressHostnameCollision{hostname: hostname}
+}
+
 func NewIngressHostnamesNotValid(invalidHostnames []string, notMatchingHostnames []string, spec v1alpha1.AllowedListSpec) error {
 	return &ingressHostnameNotValid{invalidHostnames: invalidHostnames, notMatchingHostnames: notMatchingHostnames, spec: spec}
 }

--- a/pkg/webhook/ingress/types.go
+++ b/pkg/webhook/ingress/types.go
@@ -29,11 +29,16 @@ const (
 type Ingress interface {
 	IngressClass() *string
 	Namespace() string
+	Name() string
 	Hostnames() []string
 }
 
 type NetworkingV1 struct {
 	*networkingv1.Ingress
+}
+
+func (n NetworkingV1) Name() string {
+	return n.GetName()
 }
 
 func (n NetworkingV1) IngressClass() (res *string) {
@@ -65,6 +70,10 @@ type NetworkingV1Beta1 struct {
 	*networkingv1beta.Ingress
 }
 
+func (n NetworkingV1Beta1) Name() string {
+	return n.GetName()
+}
+
 func (n NetworkingV1Beta1) IngressClass() (res *string) {
 	res = n.Spec.IngressClassName
 	if res == nil {
@@ -92,6 +101,10 @@ func (n NetworkingV1Beta1) Hostnames() []string {
 
 type Extension struct {
 	*extensionsv1beta1.Ingress
+}
+
+func (e Extension) Name() string {
+	return e.GetName()
 }
 
 func (e Extension) IngressClass() (res *string) {


### PR DESCRIPTION
Closes #215.

By default, allowing Ingress hostname collision since it's the actual behavior of Capsule: for 0.1.0 we can change this making it breaking backed by the minor release.