### PR TITLE
Fix dirty flag on Capsule builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,13 @@
 # Build the manager binary
 FROM golang:1.13 as builder
 
+ARG GIT_HEAD_COMMIT
+ARG GIT_TAG_COMMIT
+ARG GIT_LAST_TAG
+ARG GIT_MODIFIED
+ARG GIT_REPO
+ARG BUILD_DATE
+
 WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY go.mod go.mod
@@ -15,20 +22,11 @@ COPY version.go version.go
 COPY api/ api/
 COPY controllers/ controllers/
 COPY pkg/ pkg/
-COPY .git .git
 
 # Build
-RUN git config --get remote.origin.url > /tmp/GIT_REPO && \
-    git rev-parse --short HEAD > /tmp/GIT_HEAD_COMMIT && \
-    git describe --abbrev=0 --tags > /tmp/GIT_LAST_TAG && \
-    git rev-parse --short $(cat /tmp/GIT_LAST_TAG) > /tmp/GIT_TAG_COMMIT && \
-    git diff $(cat /tmp/GIT_HEAD_COMMIT) $(cat /tmp/GIT_TAG_COMMIT) --quiet > /tmp/GIT_MODIFIED1 || echo '.dev' > /tmp/GIT_MODIFIED1 && \
-    git diff --quiet > /tmp/GIT_MODIFIED2 || echo '.dirty' > /tmp/GIT_MODIFIED2 && \
-    cat /tmp/GIT_MODIFIED1 /tmp/GIT_MODIFIED2 | tr -d '\n' > /tmp/GIT_MODIFIED && \
-    date '+%Y-%m-%dT%H:%M:%S' > /tmp/BUILD_DATE &&\
-    CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build \
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build \
         -gcflags "-N -l" \
-        -ldflags "-X main.GitRepo=$(cat /tmp/GIT_REPO) -X main.GitTag=$(cat /tmp/GIT_LAST_TAG) -X main.GitCommit=$(cat /tmp/GIT_HEAD_COMMIT) -X main.GitDirty=$(cat /tmp/GIT_MODIFIED) -X main.BuildTime=$(cat /tmp/BUILD_DATE)" \
+        -ldflags "-X main.GitRepo=$GIT_REPO -X main.GitTag=$GIT_LAST_TAG -X main.GitCommit=$GIT_HEAD_COMMIT -X main.GitDirty=$GIT_MODIFIED -X main.BuildTime=$BUILD_DATE" \
         -o manager
 
 # Use distroless as minimal base image to package the manager binary


### PR DESCRIPTION
<!--
# General contribution criteria

Thanks for spending some time for improving and fixing Capsule!

We're still working on the outline of the contribution guidelines but we're
following ourselves these points:

- reference a previously opened issue: https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls#issues-and-pull-requests 
- including a sentence or two in the commit description for the
  changelog/release notes
- splitting changes into several and documented small commits
- limit the git subject to 50 characters and write as the continuation of the
  sentence "If applied, this commit will ..."
- explain what and why in the body, if more than a trivial change, wrapping at
  72 characters

If you have any issue or question, reach out us!
https://clastix.slack.com >>> #capsule channel 
-->

Fixes #213 
Hi, this will fix the dirty flag on the builds, I have moved out the `git diff` from the Dockerfile because we do not copy all the things inside the container.