### PR TITLE
Avoiding to start indexers for ingresses.networking.k8s.io on k8s < 1.19

### DIFF
--- a/pkg/indexer/add_ingress.go
+++ b/pkg/indexer/add_ingress.go
@@ -22,10 +22,17 @@ import (
 	networkingv1beta1 "k8s.io/api/networking/v1beta1"
 
 	"github.com/clastix/capsule/pkg/indexer/ingress"
+	"github.com/clastix/capsule/pkg/webhook/utils"
 )
 
 func init() {
 	AddToIndexerFuncs = append(AddToIndexerFuncs, ingress.Hostname{Obj: &extensionsv1beta1.Ingress{}})
-	AddToIndexerFuncs = append(AddToIndexerFuncs, ingress.Hostname{Obj: &networkingv1.Ingress{}})
+	// ingresses.networking.k8s.io/v1 introduced by 1.19
+	{
+		majorVer, minorVer, _, _ := utils.GetK8sVersion()
+		if majorVer == 1 && minorVer >= 19 {
+			AddToIndexerFuncs = append(AddToIndexerFuncs, ingress.Hostname{Obj: &networkingv1.Ingress{}})
+		}
+	}
 	AddToIndexerFuncs = append(AddToIndexerFuncs, ingress.Hostname{Obj: &networkingv1beta1.Ingress{}})
 }


### PR DESCRIPTION
Closes #223.

This is going to solve the flakiness we saw with older versions.