### PR TITLE
Preventing Ingress hostname collision also for Namespaces of the same Tenant

### DIFF
--- a/pkg/webhook/ingress/validating.go
+++ b/pkg/webhook/ingress/validating.go
@@ -218,9 +218,9 @@ func (r *handler) validateCollision(ctx context.Context, clt client.Client, ingr
 		return nil
 	}
 	for _, hostname := range ingress.Hostnames() {
-		var err error
 		collisionErr := NewIngressHostnameCollision(hostname)
 
+		var err error
 		switch ingress.(type) {
 		case Extension:
 			el := &extensionsv1beta1.IngressList{}
@@ -231,11 +231,12 @@ func (r *handler) validateCollision(ctx context.Context, clt client.Client, ingr
 			}
 			switch len(el.Items) {
 			case 0:
-				continue
+				break
 			case 1:
-				if el.Items[0].GetName() != ingress.Name() {
-					return collisionErr
+				if f := el.Items[0]; f.GetName() == ingress.Name() && f.GetNamespace() == ingress.Namespace() {
+					break
 				}
+				fallthrough
 			default:
 				return collisionErr
 			}
@@ -249,11 +250,12 @@ func (r *handler) validateCollision(ctx context.Context, clt client.Client, ingr
 			}
 			switch len(nl.Items) {
 			case 0:
-				continue
+				break
 			case 1:
-				if nl.Items[0].GetName() != ingress.Name() {
-					return collisionErr
+				if f := nl.Items[0]; f.GetName() == ingress.Name() && f.GetNamespace() == ingress.Namespace() {
+					break
 				}
+				fallthrough
 			default:
 				return collisionErr
 			}
@@ -267,11 +269,12 @@ func (r *handler) validateCollision(ctx context.Context, clt client.Client, ingr
 			}
 			switch len(nlb.Items) {
 			case 0:
-				continue
+				break
 			case 1:
-				if nlb.Items[0].GetName() != ingress.Name() {
-					return collisionErr
+				if f := nlb.Items[0]; f.GetName() == ingress.Name() && f.GetNamespace() == ingress.Namespace() {
+					break
 				}
+				fallthrough
 			default:
 				return collisionErr
 			}


### PR DESCRIPTION
Closes #225.

I was able to replicate the issue and solving it by testing with the step-by-step instructions provided in the issue.

```
cat <<EOF | kubectl --as alice --as-group capsule.clastix.io apply -f -
apiVersion: networking.k8s.io/v1beta1
kind: Ingress
metadata:
  name: example
  namespace: oil-production
spec:
  rules:
    - host: example.com
      http:
        paths:
          - path: /testpath
            backend:
              serviceName: test
              servicePort: 80                              
EOF                                                        
Warning: networking.k8s.io/v1beta1 Ingress is deprecated in v1.19+, unavailable in v1.22+; use networking.k8s.io/v1 Ingress
ingress.networking.k8s.io/example created

$ cat <<EOF | kubectl --as alice --as-group capsule.clastix.io apply -f -
apiVersion: networking.k8s.io/v1beta1
kind: Ingress
metadata:
  name: example2
  namespace: oil-production
spec:
  rules:
    - host: example.com
      http:
        paths:
          - path: /testpath
            backend:
              serviceName: test
              servicePort: 80
EOF
Warning: networking.k8s.io/v1beta1 Ingress is deprecated in v1.19+, unavailable in v1.22+; use networking.k8s.io/v1 Ingress
Error from server: error when creating "STDIN": admission webhook "ingress-v1beta1.capsule.clastix.io" denied the request: hostname example.com is already used across the cluster: please, reach out to the system administrators

$ cat <<EOF | kubectl --as alice --as-group capsule.clastix.io apply -f -
apiVersion: networking.k8s.io/v1beta1
kind: Ingress
metadata:
  name: example
  namespace: gas-production
spec:
  rules:
    - host: example.com
      http:
        paths:
          - path: /testpath
            backend:
              serviceName: test
              servicePort: 80
EOF
Warning: networking.k8s.io/v1beta1 Ingress is deprecated in v1.19+, unavailable in v1.22+; use networking.k8s.io/v1 Ingress
Error from server: error when creating "STDIN": admission webhook "ingress-v1beta1.capsule.clastix.io" denied the request: hostname example.com is already used across the cluster: please, reach out to the system administrators

$ cat <<EOF | kubectl --as alice --as-group capsule.clastix.io apply -f -
apiVersion: networking.k8s.io/v1beta1
kind: Ingress
metadata:
  name: example
  namespace: oil-development
spec:
  rules:
    - host: example.com
      http:
        paths:
          - path: /testpath
            backend:
              serviceName: test
              servicePort: 80
EOF
Warning: networking.k8s.io/v1beta1 Ingress is deprecated in v1.19+, unavailable in v1.22+; use networking.k8s.io/v1 Ingress
Error from server: error when creating "STDIN": admission webhook "ingress-v1beta1.capsule.clastix.io" denied the request: hostname example.com is already used across the cluster: please, reach out to the system administrators
```