### PR TITLE
Ignoring requests from kube-system ServiceAccount resources

### DIFF
--- a/pkg/utils/user_group.go
+++ b/pkg/utils/user_group.go
@@ -20,23 +20,29 @@ import (
 	"sort"
 )
 
-type UserGroupList []string
-
-func (u UserGroupList) Len() int {
-	return len(u)
+type UserGroupList interface {
+	Find(needle string) (found bool)
 }
 
-func (u UserGroupList) Less(i, j int) bool {
-	return u[i] < u[j]
+type userGroupList []string
+
+func NewUserGroupList(groups []string) UserGroupList {
+	list := make(userGroupList, len(groups))
+	for k, v := range groups {
+		list[k] = v
+	}
+	sort.SliceStable(list, func(i, j int) bool {
+		return list[i] < list[j]
+	})
+	return list
 }
 
-func (u UserGroupList) Swap(i, j int) {
-	u[i], u[j] = u[j], u[i]
-}
-
-func (u UserGroupList) IsInCapsuleGroup(capsuleGroup string) (ok bool) {
-	sort.Sort(u)
-	i := sort.SearchStrings(u, capsuleGroup)
-	ok = i < u.Len() && u[i] == capsuleGroup
+// Find sorts itself using the SliceStable and perform a binary-search for the given string.
+func (u userGroupList) Find(needle string) (found bool) {
+	sort.SliceStable(u, func(i, j int) bool {
+		return i < j
+	})
+	i := sort.SearchStrings(u, needle)
+	found = i < len(u) && u[i] == needle
 	return
 }

--- a/pkg/utils/user_group_test.go
+++ b/pkg/utils/user_group_test.go
@@ -19,5 +19,5 @@ func TestIsInCapsuleGroup(t *testing.T) {
 
 	capsuleGroup := "kubernetes-abilitytologin"
 
-	assert.True(t, UserGroupList(groups).IsInCapsuleGroup(capsuleGroup), nil)
+	assert.True(t, NewUserGroupList(groups).Find(capsuleGroup), nil)
 }


### PR DESCRIPTION
Closes #234, as well for PR #235.

This change is going to be breaking for `capsule-proxy` or any other component relying on the binary-search for the Capsule group belonging: nothing critical, it's a matter of renaming since we're performing a _search_.

With this change, we're letting Capsule to run with the Capsule group set to `system:authenticated` (although, I wouldn't suggest this) and skipping the requests performed by controller managers running in the `kube-system` Namespace.

Tested with the following steps:

1. create the KinD local dev env
2. installing Capsule with CLI flag `--capsule-user-group=system:authenticated`
3. create a Tenant
4. create the Namespace (`--as alice --as-group system:authenticated`)
5. wait for the reconciliation in order to get `NetworkPolicy` resources deployed
6. delete the Namespace
7. it works

@stg-0, since you're the reporter of the issue, may I ask you to give a try to these changes?