### PR TITLE
chore: non embedding certs for kubeconfig file generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,5 +24,7 @@ bin
 *~
 
 **/*.kubeconfig
+**/*.crt
+**/*.key
 .DS_Store
 


### PR DESCRIPTION
This is a non-production code change, it's just required to setup Capsule while testing it, during CI or e2e of other components relying on it.