### PR TITLE
refactor: better name variables in codebase

### DIFF
--- a/pkg/webhook/namespacequota/validating.go
+++ b/pkg/webhook/namespacequota/validating.go
@@ -67,13 +67,13 @@ func (r *handler) OnCreate(client client.Client, decoder *admission.Decoder) cap
 			return admission.Errored(http.StatusBadRequest, err)
 		}
 
-		for _, or := range ns.ObjectMeta.OwnerReferences {
+		for _, objectRef := range ns.ObjectMeta.OwnerReferences {
 			// retrieving the selected Tenant
-			t := &capsulev1alpha1.Tenant{}
-			if err := client.Get(ctx, types.NamespacedName{Name: or.Name}, t); err != nil {
+			tnt := &capsulev1alpha1.Tenant{}
+			if err := client.Get(ctx, types.NamespacedName{Name: objectRef.Name}, tnt); err != nil {
 				return admission.Errored(http.StatusBadRequest, err)
 			}
-			if t.IsFull() {
+			if tnt.IsFull() {
 				return admission.Denied(NewNamespaceQuotaExceededError().Error())
 			}
 		}

--- a/pkg/webhook/pvc/validating.go
+++ b/pkg/webhook/pvc/validating.go
@@ -67,25 +67,25 @@ func (h *handler) OnCreate(c client.Client, decoder *admission.Decoder) capsulew
 			return admission.Errored(http.StatusBadRequest, err)
 		}
 
-		tl := &capsulev1alpha1.TenantList{}
-		if err := c.List(ctx, tl, client.MatchingFieldsSelector{
+		tntList := &capsulev1alpha1.TenantList{}
+		if err := c.List(ctx, tntList, client.MatchingFieldsSelector{
 			Selector: fields.OneTermEqualSelector(".status.namespaces", pvc.Namespace),
 		}); err != nil {
 			return admission.Errored(http.StatusBadRequest, err)
 		}
 
-		if len(tl.Items) == 0 {
+		if len(tntList.Items) == 0 {
 			return admission.Allowed("")
 		}
 
-		tnt := tl.Items[0]
+		tnt := tntList.Items[0]
 
 		if tnt.Spec.StorageClasses == nil {
 			return admission.Allowed("")
 		}
 
 		if pvc.Spec.StorageClassName == nil {
-			return admission.Errored(http.StatusBadRequest, NewStorageClassNotValid(*tl.Items[0].Spec.StorageClasses))
+			return admission.Errored(http.StatusBadRequest, NewStorageClassNotValid(*tntList.Items[0].Spec.StorageClasses))
 		}
 
 		sc := *pvc.Spec.StorageClassName

--- a/pkg/webhook/router.go
+++ b/pkg/webhook/router.go
@@ -27,16 +27,16 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
-func Register(mgr controllerruntime.Manager, webhookList ...Webhook) error {
+func Register(manager controllerruntime.Manager, webhookList ...Webhook) error {
 	// skipping webhook setup if certificate is missing
-	dat, _ := ioutil.ReadFile("/tmp/k8s-webhook-server/serving-certs/tls.crt")
-	if len(dat) == 0 {
+	certData, _ := ioutil.ReadFile("/tmp/k8s-webhook-server/serving-certs/tls.crt")
+	if len(certData) == 0 {
 		return nil
 	}
 
-	s := mgr.GetWebhookServer()
+	server := manager.GetWebhookServer()
 	for _, wh := range webhookList {
-		s.Register(wh.GetPath(), &webhook.Admission{
+		server.Register(wh.GetPath(), &webhook.Admission{
 			Handler: &handlerRouter{
 				handler: wh.GetHandler(),
 			},

--- a/pkg/webhook/tenant/validating.go
+++ b/pkg/webhook/tenant/validating.go
@@ -112,17 +112,17 @@ func (h *handler) validateIngressHostnamesRegex(tenant *v1alpha1.Tenant) error {
 func (h *handler) validateIngressHostnamesCollision(context context.Context, clt client.Client, tenant *v1alpha1.Tenant) error {
 	if h.checkIngressHostnamesExact && tenant.Spec.IngressHostnames != nil && len(tenant.Spec.IngressHostnames.Exact) > 0 {
 		for _, h := range tenant.Spec.IngressHostnames.Exact {
-			tl := &v1alpha1.TenantList{}
-			if err := clt.List(context, tl, client.MatchingFieldsSelector{
+			tntList := &v1alpha1.TenantList{}
+			if err := clt.List(context, tntList, client.MatchingFieldsSelector{
 				Selector: fields.OneTermEqualSelector(".spec.ingressHostnames", h),
 			}); err != nil {
 				return fmt.Errorf("cannot retrieve Tenant list using .spec.ingressHostnames field selector: %w", err)
 			}
 			switch {
-			case len(tl.Items) == 1 && tl.Items[0].GetName() == tenant.GetName():
+			case len(tntList.Items) == 1 && tntList.Items[0].GetName() == tenant.GetName():
 				continue
-			case len(tl.Items) > 0:
-				return fmt.Errorf("the allowed hostname %s is already used by the Tenant %s, cannot proceed", h, tl.Items[0].GetName())
+			case len(tntList.Items) > 0:
+				return fmt.Errorf("the allowed hostname %s is already used by the Tenant %s, cannot proceed", h, tntList.Items[0].GetName())
 			default:
 				continue
 			}

--- a/pkg/webhook/tenantprefix/validating.go
+++ b/pkg/webhook/tenantprefix/validating.go
@@ -84,13 +84,13 @@ func (r *handler) OnCreate(clt client.Client, decoder *admission.Decoder) capsul
 			return admission.Allowed("")
 		}
 
-		t := &v1alpha1.Tenant{}
+		tnt := &v1alpha1.Tenant{}
 		for _, or := range ns.ObjectMeta.OwnerReferences {
 			// retrieving the selected Tenant
-			if err := clt.Get(ctx, types.NamespacedName{Name: or.Name}, t); err != nil {
+			if err := clt.Get(ctx, types.NamespacedName{Name: or.Name}, tnt); err != nil {
 				return admission.Errored(http.StatusBadRequest, err)
 			}
-			if e := fmt.Sprintf("%s-%s", t.GetName(), ns.GetName()); !strings.HasPrefix(ns.GetName(), fmt.Sprintf("%s-", t.GetName())) {
+			if e := fmt.Sprintf("%s-%s", tnt.GetName(), ns.GetName()); !strings.HasPrefix(ns.GetName(), fmt.Sprintf("%s-", tnt.GetName())) {
 				return admission.Denied("The namespace doesn't match the tenant prefix, expected " + e)
 			}
 		}

--- a/pkg/webhook/utils/in_capsule_group.go
+++ b/pkg/webhook/utils/in_capsule_group.go
@@ -40,14 +40,14 @@ type handler struct {
 
 // If the user performing action is not a Capsule user, can be skipped
 func (h handler) isCapsuleUser(req admission.Request) bool {
-	g := utils.NewUserGroupList(req.UserInfo.Groups)
+	groupList := utils.NewUserGroupList(req.UserInfo.Groups)
 	// if the user is a ServiceAccount belonging to the kube-system namespace, definitely, it's not a Capsule user
 	// and we can skip the check in case of Capsule user group assigned to system:authenticated
 	// (ref: https://github.com/clastix/capsule/issues/234)
-	if g.Find("system:serviceaccounts:kube-system") {
+	if groupList.Find("system:serviceaccounts:kube-system") {
 		return false
 	}
-	return g.Find(h.capsuleGroup)
+	return groupList.Find(h.capsuleGroup)
 }
 
 func (h *handler) OnCreate(client client.Client, decoder *admission.Decoder) webhook.Func {

--- a/pkg/webhook/utils/kubernetes_version.go
+++ b/pkg/webhook/utils/kubernetes_version.go
@@ -24,12 +24,12 @@ func GetK8sVersion() (major, minor int, ver string, err error) {
 		return 0, 0, "", err
 	}
 
-	v, err := client.Discovery().ServerVersion()
+	version, err := client.Discovery().ServerVersion()
 	if err != nil {
 		return 0, 0, "", err
 	}
-	major, _ = strconv.Atoi(v.Major)
-	minor, _ = strconv.Atoi(v.Minor)
-	ver = v.String()
+	major, _ = strconv.Atoi(version.Major)
+	minor, _ = strconv.Atoi(version.Minor)
+	ver = version.String()
 	return
 }


### PR DESCRIPTION
<!--
# General contribution criteria

Thanks for spending some time for improving and fixing Capsule!

We're still working on the outline of the contribution guidelines but we're
following ourselves these points:

- reference a previously opened issue: https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls#issues-and-pull-requests 
- including a sentence or two in the commit description for the
  changelog/release notes
- splitting changes into several and documented small commits
- limit the git subject to 50 characters and write as the continuation of the
  sentence "If applied, this commit will ..."
- explain what and why in the body, if more than a trivial change, wrapping at
  72 characters

If you have any issue or question, reach out us!
https://clastix.slack.com >>> #capsule channel 
-->

This is a WP PR to solve #164 

I plan to check the codebase file by file to improve variables names.
This is my approach to choose if a variable should be renamed:
I'm trying to understand the variable meaning by reading the code, if I need to search in the code base for that meaning, then I rename the variable.

Started with

- [x] main.go
- [x] pkg/webhook
- [x] pkg/webhook/ingress
- [x] pkg/webhook/namespacequota
- [x] pkg/webhook/ownerreference
- [x] pkg/webhook/registry
- [x] pkg/webhook/services
- [x] pkg/webhook/tenant
- [x] pkg/webhook/tenantprefix
- [x] pkg/webhook/utils

@prometherion let me know if you like it and if you think I should continue.  