### PR TITLE
Docker-ci for armv7 / arm64 support 

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -1,0 +1,73 @@
+name: docker-ci
+
+on:
+  push:
+    tags:        
+      - "v*"
+
+jobs:
+  docker-ci:
+    runs-on: ubuntu-20.04
+    steps:
+
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+
+      -
+        name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: |
+             quay.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{raw}}
+          flavor: |
+            latest=false
+
+      -
+        name: Set up QEMU
+        id: qemu
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: arm64,arm
+
+      -
+        name: Set up Docker Buildx
+        id: buildx
+        with:
+          install: true
+        uses: docker/setup-buildx-action@v1
+
+      -
+        name: Inspect builder
+        run: |
+          echo "Name:      ${{ steps.buildx.outputs.name }}"
+          echo "Endpoint:  ${{ steps.buildx.outputs.endpoint }}"
+          echo "Status:    ${{ steps.buildx.outputs.status }}"
+          echo "Flags:     ${{ steps.buildx.outputs.flags }}"
+          echo "Platforms: ${{ steps.buildx.outputs.platforms }}"
+
+      -
+        name: Login to quay.io Container Registry
+        uses: docker/login-action@v1 
+        with:
+          registry: quay.io
+          username: ${{ github.repository_owner }}+github
+          password: ${{ secrets.BOT_QUAY_IO }}
+
+      -
+        name: Build and push
+        id: build-release
+        uses: docker/build-push-action@v2
+        with:
+          file: Dockerfile
+          context: .
+          platforms: linux/amd64,linux/arm64,linux/arm
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+
+      -
+        name: Image digest
+        run: echo ${{ steps.build-release.outputs.digest }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 # Build the manager binary
-FROM quay.io/bitnami/golang:1.16 as builder
+FROM golang:1.16 as builder
 
+ARG TARGETARCH
 ARG GIT_HEAD_COMMIT
 ARG GIT_TAG_COMMIT
 ARG GIT_LAST_TAG
@@ -24,7 +25,7 @@ COPY controllers/ controllers/
 COPY pkg/ pkg/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build \
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH GO111MODULE=on go build \
         -gcflags "-N -l" \
         -ldflags "-X main.GitRepo=$GIT_REPO -X main.GitTag=$GIT_LAST_TAG -X main.GitCommit=$GIT_HEAD_COMMIT -X main.GitDirty=$GIT_MODIFIED -X main.BuildTime=$BUILD_DATE" \
         -o manager

--- a/charts/capsule/values.yaml
+++ b/charts/capsule/values.yaml
@@ -33,9 +33,9 @@ manager:
       memory: 128Mi
 jobs:
   image:
-    repository: bitnami/kubectl
+    repository: quay.io/clastix/kubectl
     pullPolicy: IfNotPresent
-    tag: "1.18"
+    tag: "v1.20.7"
 mutatingWebhooksTimeoutSeconds: 30
 validatingWebhooksTimeoutSeconds: 30
 imagePullSecrets: []


### PR DESCRIPTION
Closes #244

- Added armv7 / arm64 support (k8s deprecated armv6)
- Automated docker buildx & push to clastix quay.io registry using github actions
- Added proprietary kubectl image from quay.io

Completely tested on amd64 / arm64

<!--
# General contribution criteria

Thanks for spending some time for improving and fixing Capsule!

We're still working on the outline of the contribution guidelines but we're
following ourselves these points:

- reference a previously opened issue: https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls#issues-and-pull-requests 
- including a sentence or two in the commit description for the
  changelog/release notes
- splitting changes into several and documented small commits
- limit the git subject to 50 characters and write as the continuation of the
  sentence "If applied, this commit will ..."
- explain what and why in the body, if more than a trivial change, wrapping at
  72 characters

If you have any issue or question, reach out us!
https://clastix.slack.com >>> #capsule channel 
-->
