### PR TITLE
feat: add description fields in crd

### DIFF
--- a/api/v1beta1/owner.go
+++ b/api/v1beta1/owner.go
@@ -3,10 +3,12 @@
 
 package v1beta1
 
-// OwnerSpec defines tenant owner name and kind
 type OwnerSpec struct {
-	Kind            OwnerKind       `json:"kind"`
-	Name            string          `json:"name"`
+	// Kind of tenant owner. Possible values are "User", "Group", and "ServiceAccount"
+	Kind OwnerKind `json:"kind"`
+	// Name of tenant owner.
+	Name string `json:"name"`
+	// Proxy settings for tenant owner.
 	ProxyOperations []ProxySettings `json:"proxySettings,omitempty"`
 }
 

--- a/api/v1beta1/tenant_status.go
+++ b/api/v1beta1/tenant_status.go
@@ -11,10 +11,13 @@ const (
 	TenantStateCordoned tenantState = "cordoned"
 )
 
-// TenantStatus defines the observed state of Tenant
+// Returns the observed state of the Tenant
 type TenantStatus struct {
 	//+kubebuilder:default=active
-	State      tenantState `json:"state"`
-	Size       uint        `json:"size"`
-	Namespaces []string    `json:"namespaces,omitempty"`
+	// The operational state of the Tenant. Possible values are "active", "cordoned".
+	State tenantState `json:"state"`
+	// How many namespaces are assigned to the Tenant.
+	Size uint `json:"size"`
+	// List of namespaces assigned to the Tenant.
+	Namespaces []string `json:"namespaces,omitempty"`
 }

--- a/api/v1beta1/tenant_types.go
+++ b/api/v1beta1/tenant_types.go
@@ -9,26 +9,43 @@ import (
 
 // TenantSpec defines the desired state of Tenant
 type TenantSpec struct {
+	// Specifies the owners of the Tenant. Mandatory.
 	Owners []OwnerSpec `json:"owners"`
 
 	//+kubebuilder:validation:Minimum=1
-	NamespaceQuota         *int32                       `json:"namespaceQuota,omitempty"`
-	NamespacesMetadata     *AdditionalMetadataSpec      `json:"namespacesMetadata,omitempty"`
-	ServicesMetadata       *AdditionalMetadataSpec      `json:"servicesMetadata,omitempty"`
-	StorageClasses         *AllowedListSpec             `json:"storageClasses,omitempty"`
-	IngressClasses         *AllowedListSpec             `json:"ingressClasses,omitempty"`
-	IngressHostnames       *AllowedListSpec             `json:"ingressHostnames,omitempty"`
-	ContainerRegistries    *AllowedListSpec             `json:"containerRegistries,omitempty"`
-	NodeSelector           map[string]string            `json:"nodeSelector,omitempty"`
-	NetworkPolicies        *NetworkPolicySpec           `json:"networkPolicies,omitempty"`
-	LimitRanges            *LimitRangesSpec             `json:"limitRanges,omitempty"`
-	ResourceQuota          *ResourceQuotaSpec           `json:"resourceQuotas,omitempty"`
+	// Specifies the maximum number of namespaces allowed for that Tenant. Once the namespace quota assigned to the Tenant has been reached, the Tenant owner cannot create further namespaces. Optional.
+	NamespaceQuota *int32 `json:"namespaceQuota,omitempty"`
+	// Specifies additional labels and annotations the Capsule operator places on any Namespace resource in the Tenant. Optional.
+	NamespacesMetadata *AdditionalMetadataSpec `json:"namespacesMetadata,omitempty"`
+	// Specifies additional labels and annotations the Capsule operator places on any Service resource in the Tenant. Optional.
+	ServicesMetadata *AdditionalMetadataSpec `json:"servicesMetadata,omitempty"`
+	// Specifies the allowed StorageClasses assigned to the Tenant. Capsule assures that all PersistentVolumeClaim resources created in the Tenant can use only one of the allowed StorageClasses. Optional.
+	StorageClasses *AllowedListSpec `json:"storageClasses,omitempty"`
+	// Specifies the allowed IngressClasses assigned to the Tenant. Capsule assures that all Ingress resources created in the Tenant can use only one of the allowed IngressClasses. Optional.
+	IngressClasses *AllowedListSpec `json:"ingressClasses,omitempty"`
+	// Specifies the allowed hostnames in Ingresses for the given Tenant. Capsule assures that all Ingress resources created in the Tenant can use only one of the allowed hostnames. Optional.
+	IngressHostnames *AllowedListSpec `json:"ingressHostnames,omitempty"`
+	// Specifies the trusted Image Registries assigned to the Tenant. Capsule assures that all Pods resources created in the Tenant can use only one of the allowed trusted registries. Optional.
+	ContainerRegistries *AllowedListSpec `json:"containerRegistries,omitempty"`
+	// Specifies the label to control the placement of pods on a given pool of worker nodes. All namesapces created within the Tenant will have the node selector annotation. This annotation tells the Kubernetes scheduler to place pods on the nodes having the selector label. Optional.
+	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
+	// Specifies the NetworkPolicies assigned to the Tenant. The assigned NetworkPolicies are inherited by any namespace created in the Tenant. Optional.
+	NetworkPolicies *NetworkPolicySpec `json:"networkPolicies,omitempty"`
+	// Specifies the NetworkPolicies assigned to the Tenant. The assigned NetworkPolicies are inherited by any namespace created in the Tenant. Optional.
+	LimitRanges *LimitRangesSpec `json:"limitRanges,omitempty"`
+	// Specifies a list of ResourceQuota resources assigned to the Tenant. The assigned values are inherited by any namespace created in the Tenant. The Capsule operator aggregates ResourceQuota at Tenant level, so that the hard quota is never crossed for the given Tenant. This permits the Tenant owner to consume resources in the Tenant regardless of the namespace. Optional.
+	ResourceQuota *ResourceQuotaSpec `json:"resourceQuotas,omitempty"`
+	// Specifies additional RoleBindings assigned to the Tenant. Capsule will ensure that all namespaces in the Tenant always contain the RoleBinding for the given ClusterRole. Optional.
 	AdditionalRoleBindings []AdditionalRoleBindingsSpec `json:"additionalRoleBindings,omitempty"`
-	ExternalServiceIPs     *ExternalServiceIPsSpec      `json:"externalServiceIPs,omitempty"`
-	ImagePullPolicies      []ImagePullPolicySpec        `json:"imagePullPolicies,omitempty"`
-	PriorityClasses        *AllowedListSpec             `json:"priorityClasses,omitempty"`
+	// Specifies the external IPs that can be used in Services with type ClusterIP. An empty list means all the IPs are allowed. Optional.
+	ExternalServiceIPs *ExternalServiceIPsSpec `json:"externalServiceIPs,omitempty"`
+	// Specify the allowed values for the imagePullPolicies option in Pod resources. Capsule assures that all Pod resources created in the Tenant can use only one of the allowed policy. Optional.
+	ImagePullPolicies []ImagePullPolicySpec `json:"imagePullPolicies,omitempty"`
+	// Specifies the allowed IngressClasses assigned to the Tenant. Capsule assures that all Ingress resources created in the Tenant can use only one of the allowed IngressClasses. Optional.
+	PriorityClasses *AllowedListSpec `json:"priorityClasses,omitempty"`
 
 	//+kubebuilder:default=true
+	// Specifies if NodePort service type resources are allowed for the Tenant. Default is true. Optional.
 	EnableNodePorts *bool `json:"enableNodePorts,omitempty"`
 }
 

--- a/charts/capsule/crds/tenant-crd.yaml
+++ b/charts/capsule/crds/tenant-crd.yaml
@@ -3,6 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.5.0
+  creationTimestamp: null
   name: tenants.capsule.clastix.io
 spec:
   conversion:
@@ -564,7 +565,7 @@ spec:
       served: true
       storage: false
       subresources:
-        status: { }
+        status: {}
     - additionalPrinterColumns:
         - description: The actual state of the Tenant
           jsonPath: .status.state
@@ -603,6 +604,7 @@ spec:
               description: TenantSpec defines the desired state of Tenant
               properties:
                 additionalRoleBindings:
+                  description: Specifies additional RoleBindings assigned to the Tenant. Capsule will ensure that all namespaces in the Tenant always contain the RoleBinding for the given ClusterRole. Optional.
                   items:
                     properties:
                       clusterRoleName:
@@ -635,6 +637,7 @@ spec:
                     type: object
                   type: array
                 containerRegistries:
+                  description: Specifies the trusted Image Registries assigned to the Tenant. Capsule assures that all Pods resources created in the Tenant can use only one of the allowed trusted registries. Optional.
                   properties:
                     allowed:
                       items:
@@ -645,8 +648,10 @@ spec:
                   type: object
                 enableNodePorts:
                   default: true
+                  description: Specifies if NodePort service type resources are allowed for the Tenant. Default is true. Optional.
                   type: boolean
                 externalServiceIPs:
+                  description: Specifies the external IPs that can be used in Services with type ClusterIP. An empty list means all the IPs are allowed. Optional.
                   properties:
                     allowed:
                       items:
@@ -657,6 +662,7 @@ spec:
                     - allowed
                   type: object
                 imagePullPolicies:
+                  description: Specify the allowed values for the imagePullPolicies option in Pod resources. Capsule assures that all Pod resources created in the Tenant can use only one of the allowed policy. Optional.
                   items:
                     enum:
                       - Always
@@ -665,6 +671,7 @@ spec:
                     type: string
                   type: array
                 ingressClasses:
+                  description: Specifies the allowed IngressClasses assigned to the Tenant. Capsule assures that all Ingress resources created in the Tenant can use only one of the allowed IngressClasses. Optional.
                   properties:
                     allowed:
                       items:
@@ -674,6 +681,7 @@ spec:
                       type: string
                   type: object
                 ingressHostnames:
+                  description: Specifies the allowed hostnames in Ingresses for the given Tenant. Capsule assures that all Ingress resources created in the Tenant can use only one of the allowed hostnames. Optional.
                   properties:
                     allowed:
                       items:
@@ -683,6 +691,7 @@ spec:
                       type: string
                   type: object
                 limitRanges:
+                  description: Specifies the NetworkPolicies assigned to the Tenant. The assigned NetworkPolicies are inherited by any namespace created in the Tenant. Optional.
                   properties:
                     items:
                       items:
@@ -751,10 +760,12 @@ spec:
                       type: array
                   type: object
                 namespaceQuota:
+                  description: Specifies the maximum number of namespaces allowed for that Tenant. Once the namespace quota assigned to the Tenant has been reached, the Tenant owner cannot create further namespaces. Optional.
                   format: int32
                   minimum: 1
                   type: integer
                 namespacesMetadata:
+                  description: Specifies additional labels and annotations the Capsule operator places on any Namespace resource in the Tenant. Optional.
                   properties:
                     additionalAnnotations:
                       additionalProperties:
@@ -766,6 +777,7 @@ spec:
                       type: object
                   type: object
                 networkPolicies:
+                  description: Specifies the NetworkPolicies assigned to the Tenant. The assigned NetworkPolicies are inherited by any namespace created in the Tenant. Optional.
                   properties:
                     items:
                       items:
@@ -1025,20 +1037,24 @@ spec:
                 nodeSelector:
                   additionalProperties:
                     type: string
+                  description: Specifies the label to control the placement of pods on a given pool of worker nodes. All namesapces created within the Tenant will have the node selector annotation. This annotation tells the Kubernetes scheduler to place pods on the nodes having the selector label. Optional.
                   type: object
                 owners:
+                  description: Specifies the owners of the Tenant. Mandatory.
                   items:
-                    description: OwnerSpec defines tenant owner name and kind
                     properties:
                       kind:
+                        description: Kind of tenant owner. Possible values are "User", "Group", and "ServiceAccount"
                         enum:
                           - User
                           - Group
                           - ServiceAccount
                         type: string
                       name:
+                        description: Name of tenant owner.
                         type: string
                       proxySettings:
+                        description: Proxy settings for tenant owner.
                         items:
                           properties:
                             kind:
@@ -1066,6 +1082,7 @@ spec:
                     type: object
                   type: array
                 priorityClasses:
+                  description: Specifies the allowed IngressClasses assigned to the Tenant. Capsule assures that all Ingress resources created in the Tenant can use only one of the allowed IngressClasses. Optional.
                   properties:
                     allowed:
                       items:
@@ -1075,6 +1092,7 @@ spec:
                       type: string
                   type: object
                 resourceQuotas:
+                  description: Specifies a list of ResourceQuota resources assigned to the Tenant. The assigned values are inherited by any namespace created in the Tenant. The Capsule operator aggregates ResourceQuota at Tenant level, so that the hard quota is never crossed for the given Tenant. This permits the Tenant owner to consume resources in the Tenant regardless of the namespace. Optional.
                   properties:
                     items:
                       items:
@@ -1124,6 +1142,7 @@ spec:
                       type: array
                   type: object
                 servicesMetadata:
+                  description: Specifies additional labels and annotations the Capsule operator places on any Service resource in the Tenant. Optional.
                   properties:
                     additionalAnnotations:
                       additionalProperties:
@@ -1135,6 +1154,7 @@ spec:
                       type: object
                   type: object
                 storageClasses:
+                  description: Specifies the allowed StorageClasses assigned to the Tenant. Capsule assures that all PersistentVolumeClaim resources created in the Tenant can use only one of the allowed StorageClasses. Optional.
                   properties:
                     allowed:
                       items:
@@ -1147,16 +1167,19 @@ spec:
                 - owners
               type: object
             status:
-              description: TenantStatus defines the observed state of Tenant
+              description: Returns the observed state of the Tenant
               properties:
                 namespaces:
+                  description: List of namespaces assigned to the Tenant.
                   items:
                     type: string
                   type: array
                 size:
+                  description: How many namespaces are assigned to the Tenant.
                   type: integer
                 state:
                   default: active
+                  description: The operational state of the Tenant. Possible values are "active", "cordoned".
                   enum:
                     - cordoned
                     - active
@@ -1169,7 +1192,7 @@ spec:
       served: true
       storage: true
       subresources:
-        status: { }
+        status: {}
 status:
   acceptedNames:
     kind: ""

--- a/config/crd/bases/capsule.clastix.io_tenants.yaml
+++ b/config/crd/bases/capsule.clastix.io_tenants.yaml
@@ -604,6 +604,7 @@ spec:
             description: TenantSpec defines the desired state of Tenant
             properties:
               additionalRoleBindings:
+                description: Specifies additional RoleBindings assigned to the Tenant. Capsule will ensure that all namespaces in the Tenant always contain the RoleBinding for the given ClusterRole. Optional.
                 items:
                   properties:
                     clusterRoleName:
@@ -636,6 +637,7 @@ spec:
                   type: object
                 type: array
               containerRegistries:
+                description: Specifies the trusted Image Registries assigned to the Tenant. Capsule assures that all Pods resources created in the Tenant can use only one of the allowed trusted registries. Optional.
                 properties:
                   allowed:
                     items:
@@ -646,8 +648,10 @@ spec:
                 type: object
               enableNodePorts:
                 default: true
+                description: Specifies if NodePort service type resources are allowed for the Tenant. Default is true. Optional.
                 type: boolean
               externalServiceIPs:
+                description: Specifies the external IPs that can be used in Services with type ClusterIP. An empty list means all the IPs are allowed. Optional.
                 properties:
                   allowed:
                     items:
@@ -658,6 +662,7 @@ spec:
                 - allowed
                 type: object
               imagePullPolicies:
+                description: Specify the allowed values for the imagePullPolicies option in Pod resources. Capsule assures that all Pod resources created in the Tenant can use only one of the allowed policy. Optional.
                 items:
                   enum:
                   - Always
@@ -666,6 +671,7 @@ spec:
                   type: string
                 type: array
               ingressClasses:
+                description: Specifies the allowed IngressClasses assigned to the Tenant. Capsule assures that all Ingress resources created in the Tenant can use only one of the allowed IngressClasses. Optional.
                 properties:
                   allowed:
                     items:
@@ -675,6 +681,7 @@ spec:
                     type: string
                 type: object
               ingressHostnames:
+                description: Specifies the allowed hostnames in Ingresses for the given Tenant. Capsule assures that all Ingress resources created in the Tenant can use only one of the allowed hostnames. Optional.
                 properties:
                   allowed:
                     items:
@@ -684,6 +691,7 @@ spec:
                     type: string
                 type: object
               limitRanges:
+                description: Specifies the NetworkPolicies assigned to the Tenant. The assigned NetworkPolicies are inherited by any namespace created in the Tenant. Optional.
                 properties:
                   items:
                     items:
@@ -752,10 +760,12 @@ spec:
                     type: array
                 type: object
               namespaceQuota:
+                description: Specifies the maximum number of namespaces allowed for that Tenant. Once the namespace quota assigned to the Tenant has been reached, the Tenant owner cannot create further namespaces. Optional.
                 format: int32
                 minimum: 1
                 type: integer
               namespacesMetadata:
+                description: Specifies additional labels and annotations the Capsule operator places on any Namespace resource in the Tenant. Optional.
                 properties:
                   additionalAnnotations:
                     additionalProperties:
@@ -767,6 +777,7 @@ spec:
                     type: object
                 type: object
               networkPolicies:
+                description: Specifies the NetworkPolicies assigned to the Tenant. The assigned NetworkPolicies are inherited by any namespace created in the Tenant. Optional.
                 properties:
                   items:
                     items:
@@ -1026,20 +1037,24 @@ spec:
               nodeSelector:
                 additionalProperties:
                   type: string
+                description: Specifies the label to control the placement of pods on a given pool of worker nodes. All namesapces created within the Tenant will have the node selector annotation. This annotation tells the Kubernetes scheduler to place pods on the nodes having the selector label. Optional.
                 type: object
               owners:
+                description: Specifies the owners of the Tenant. Mandatory.
                 items:
-                  description: OwnerSpec defines tenant owner name and kind
                   properties:
                     kind:
+                      description: Kind of tenant owner. Possible values are "User", "Group", and "ServiceAccount"
                       enum:
                       - User
                       - Group
                       - ServiceAccount
                       type: string
                     name:
+                      description: Name of tenant owner.
                       type: string
                     proxySettings:
+                      description: Proxy settings for tenant owner.
                       items:
                         properties:
                           kind:
@@ -1067,6 +1082,7 @@ spec:
                   type: object
                 type: array
               priorityClasses:
+                description: Specifies the allowed IngressClasses assigned to the Tenant. Capsule assures that all Ingress resources created in the Tenant can use only one of the allowed IngressClasses. Optional.
                 properties:
                   allowed:
                     items:
@@ -1076,6 +1092,7 @@ spec:
                     type: string
                 type: object
               resourceQuotas:
+                description: Specifies a list of ResourceQuota resources assigned to the Tenant. The assigned values are inherited by any namespace created in the Tenant. The Capsule operator aggregates ResourceQuota at Tenant level, so that the hard quota is never crossed for the given Tenant. This permits the Tenant owner to consume resources in the Tenant regardless of the namespace. Optional.
                 properties:
                   items:
                     items:
@@ -1125,6 +1142,7 @@ spec:
                     type: array
                 type: object
               servicesMetadata:
+                description: Specifies additional labels and annotations the Capsule operator places on any Service resource in the Tenant. Optional.
                 properties:
                   additionalAnnotations:
                     additionalProperties:
@@ -1136,6 +1154,7 @@ spec:
                     type: object
                 type: object
               storageClasses:
+                description: Specifies the allowed StorageClasses assigned to the Tenant. Capsule assures that all PersistentVolumeClaim resources created in the Tenant can use only one of the allowed StorageClasses. Optional.
                 properties:
                   allowed:
                     items:
@@ -1148,16 +1167,19 @@ spec:
             - owners
             type: object
           status:
-            description: TenantStatus defines the observed state of Tenant
+            description: Returns the observed state of the Tenant
             properties:
               namespaces:
+                description: List of namespaces assigned to the Tenant.
                 items:
                   type: string
                 type: array
               size:
+                description: How many namespaces are assigned to the Tenant.
                 type: integer
               state:
                 default: active
+                description: The operational state of the Tenant. Possible values are "active", "cordoned".
                 enum:
                 - cordoned
                 - active

--- a/config/install.yaml
+++ b/config/install.yaml
@@ -683,6 +683,7 @@ spec:
             description: TenantSpec defines the desired state of Tenant
             properties:
               additionalRoleBindings:
+                description: Specifies additional RoleBindings assigned to the Tenant. Capsule will ensure that all namespaces in the Tenant always contain the RoleBinding for the given ClusterRole. Optional.
                 items:
                   properties:
                     clusterRoleName:
@@ -715,6 +716,7 @@ spec:
                   type: object
                 type: array
               containerRegistries:
+                description: Specifies the trusted Image Registries assigned to the Tenant. Capsule assures that all Pods resources created in the Tenant can use only one of the allowed trusted registries. Optional.
                 properties:
                   allowed:
                     items:
@@ -725,8 +727,10 @@ spec:
                 type: object
               enableNodePorts:
                 default: true
+                description: Specifies if NodePort service type resources are allowed for the Tenant. Default is true. Optional.
                 type: boolean
               externalServiceIPs:
+                description: Specifies the external IPs that can be used in Services with type ClusterIP. An empty list means all the IPs are allowed. Optional.
                 properties:
                   allowed:
                     items:
@@ -737,6 +741,7 @@ spec:
                 - allowed
                 type: object
               imagePullPolicies:
+                description: Specify the allowed values for the imagePullPolicies option in Pod resources. Capsule assures that all Pod resources created in the Tenant can use only one of the allowed policy. Optional.
                 items:
                   enum:
                   - Always
@@ -745,6 +750,7 @@ spec:
                   type: string
                 type: array
               ingressClasses:
+                description: Specifies the allowed IngressClasses assigned to the Tenant. Capsule assures that all Ingress resources created in the Tenant can use only one of the allowed IngressClasses. Optional.
                 properties:
                   allowed:
                     items:
@@ -754,6 +760,7 @@ spec:
                     type: string
                 type: object
               ingressHostnames:
+                description: Specifies the allowed hostnames in Ingresses for the given Tenant. Capsule assures that all Ingress resources created in the Tenant can use only one of the allowed hostnames. Optional.
                 properties:
                   allowed:
                     items:
@@ -763,6 +770,7 @@ spec:
                     type: string
                 type: object
               limitRanges:
+                description: Specifies the NetworkPolicies assigned to the Tenant. The assigned NetworkPolicies are inherited by any namespace created in the Tenant. Optional.
                 properties:
                   items:
                     items:
@@ -831,10 +839,12 @@ spec:
                     type: array
                 type: object
               namespaceQuota:
+                description: Specifies the maximum number of namespaces allowed for that Tenant. Once the namespace quota assigned to the Tenant has been reached, the Tenant owner cannot create further namespaces. Optional.
                 format: int32
                 minimum: 1
                 type: integer
               namespacesMetadata:
+                description: Specifies additional labels and annotations the Capsule operator places on any Namespace resource in the Tenant. Optional.
                 properties:
                   additionalAnnotations:
                     additionalProperties:
@@ -846,6 +856,7 @@ spec:
                     type: object
                 type: object
               networkPolicies:
+                description: Specifies the NetworkPolicies assigned to the Tenant. The assigned NetworkPolicies are inherited by any namespace created in the Tenant. Optional.
                 properties:
                   items:
                     items:
@@ -1105,20 +1116,24 @@ spec:
               nodeSelector:
                 additionalProperties:
                   type: string
+                description: Specifies the label to control the placement of pods on a given pool of worker nodes. All namesapces created within the Tenant will have the node selector annotation. This annotation tells the Kubernetes scheduler to place pods on the nodes having the selector label. Optional.
                 type: object
               owners:
+                description: Specifies the owners of the Tenant. Mandatory.
                 items:
-                  description: OwnerSpec defines tenant owner name and kind
                   properties:
                     kind:
+                      description: Kind of tenant owner. Possible values are "User", "Group", and "ServiceAccount"
                       enum:
                       - User
                       - Group
                       - ServiceAccount
                       type: string
                     name:
+                      description: Name of tenant owner.
                       type: string
                     proxySettings:
+                      description: Proxy settings for tenant owner.
                       items:
                         properties:
                           kind:
@@ -1146,6 +1161,7 @@ spec:
                   type: object
                 type: array
               priorityClasses:
+                description: Specifies the allowed IngressClasses assigned to the Tenant. Capsule assures that all Ingress resources created in the Tenant can use only one of the allowed IngressClasses. Optional.
                 properties:
                   allowed:
                     items:
@@ -1155,6 +1171,7 @@ spec:
                     type: string
                 type: object
               resourceQuotas:
+                description: Specifies a list of ResourceQuota resources assigned to the Tenant. The assigned values are inherited by any namespace created in the Tenant. The Capsule operator aggregates ResourceQuota at Tenant level, so that the hard quota is never crossed for the given Tenant. This permits the Tenant owner to consume resources in the Tenant regardless of the namespace. Optional.
                 properties:
                   items:
                     items:
@@ -1204,6 +1221,7 @@ spec:
                     type: array
                 type: object
               servicesMetadata:
+                description: Specifies additional labels and annotations the Capsule operator places on any Service resource in the Tenant. Optional.
                 properties:
                   additionalAnnotations:
                     additionalProperties:
@@ -1215,6 +1233,7 @@ spec:
                     type: object
                 type: object
               storageClasses:
+                description: Specifies the allowed StorageClasses assigned to the Tenant. Capsule assures that all PersistentVolumeClaim resources created in the Tenant can use only one of the allowed StorageClasses. Optional.
                 properties:
                   allowed:
                     items:
@@ -1227,16 +1246,19 @@ spec:
             - owners
             type: object
           status:
-            description: TenantStatus defines the observed state of Tenant
+            description: Returns the observed state of the Tenant
             properties:
               namespaces:
+                description: List of namespaces assigned to the Tenant.
                 items:
                   type: string
                 type: array
               size:
+                description: How many namespaces are assigned to the Tenant.
                 type: integer
               state:
                 default: active
+                description: The operational state of the Tenant. Possible values are "active", "cordoned".
                 enum:
                 - cordoned
                 - active


### PR DESCRIPTION
close #322 

```
$ kubectl explain tnt.spec
KIND:     Tenant
VERSION:  capsule.clastix.io/v1beta1

RESOURCE: spec <Object>

DESCRIPTION:
     TenantSpec defines the desired state of Tenant

FIELDS:
   additionalRoleBindings       <[]Object>
     Specifies additional RoleBindings assigned to the Tenant. Capsule will
     ensure that all namespaces in the Tenant always contain the RoleBinding for
     the given ClusterRole. Optional.

   containerRegistries  <Object>
     Specifies the trusted Image Registries assigned to the Tenant. Capsule
     assures that all Pods resources created in the Tenant can use only one of
     the allowed trusted registries. Optional.

   enableNodePorts      <boolean>
     Specifies if NodePort service type resources are allowed for the Tenant.
     Dafault is true. Optional.

   externalServiceIPs   <Object>
     Specifies the external IPs that can be used in Services with type
     ClusterIP. An empty list means all the IPs are allowed. Optional.

   imagePullPolicies    <[]string>
     Specify the allowed values for the imagePullPolicies option in Pod
     resources. Capsule assures that all Pod resources created in the Tenant can
     use only one of the allowed policy. Optional.

   ingressClasses       <Object>
     Specifies the allowed IngressClasses assigned to the Tenant. Capsule
     assures that all Ingress resources created in the Tenant can use only one
     of the allowed IngressClasses. Optional.

   ingressHostnames     <Object>
     Specifies the allowed hostnames in Ingresses for the given Tenant. Capsule
     assures that all Ingress resources created in the Tenant can use only one
     of the allowed hostnames. Optional.

   limitRanges  <Object>
     Specifies the LimitRanges assigned to the Tenant. The assigned LimitRanges
     are inherited by any namespace created in the Tenant. Optional.

   namespaceQuota       <integer>
     Specifies the maximum number of namespaces allowed for that Tenant. Once
     the namespace quota assigned to the Tenant has been reached, the Tenant
     owner cannot create further namespaces. Optional.

   namespacesMetadata   <Object>
     Specifies additional labels and annotations the Capsule operator places on
     any Namespace resource in the Tenant. Optional.

   networkPolicies      <Object>
     Specifies the NetworkPolicies assigned to the Tenant. The assigned
     NetworkPolicies are inherited by any namespace created in the Tenant.
     Optional.

   nodeSelector <map[string]string>
     Specifies the label to control the placement of pods on a given pool of
     worker nodes. All namesapces created within the Tenant will have the node
     selector annotation. This annotation tells the Kubernetes scheduler to
     place pods on the nodes having the selector label. Optional.

   owners       <[]Object> -required-
     Specifies the owners of the Tenant. Mandatory.

   priorityClasses      <Object>
     Specifies the allowed PriorityClasses assigned to the Tenant. Capsule
     assures that all Pod resources created in the Tenant can use only one of
     the allowed PriorityClasses. Optional.

   resourceQuotas       <Object>
     Specifies a list of ResourceQuota resources assigned to the Tenant. The
     assigned values are inherited by any namespace created in the Tenant. The
     Capsule operator aggregates ResourceQuota at Tenant level, so that the hard
     quota is never crossed for the given Tenant. This permits the Tenant owner
     to consume resources in the Tenant regardless of the namespace. Optional.

   servicesMetadata     <Object>
     Specifies additional labels and annotations the Capsule operator places on
     any Service resource in the Tenant. Optional.

   storageClasses       <Object>
     Specifies the allowed StorageClasses assigned to the Tenant. Capsule
     assures that all PersistentVolumeClaim resources created in the Tenant can
     use only one of the allowed StorageClasses. Optional.
```

and

```
$ kubectl explain tnt.statuså
KIND:     Tenant
VERSION:  capsule.clastix.io/v1beta1

RESOURCE: status <Object>

DESCRIPTION:
     TenantStatus defines the observed state of Tenant

FIELDS:
   namespaces   <[]string>
     The list of namespaces assigned to the Tenant.

   size <integer> -required-
     How many namespaces are assigned to the Tenant.

   state        <string> -required-
     The operational state of the Tenant. Possible values are "active",
     "cordoned".

```