### PR TITLE
Add signerName in CSR hack script

### DIFF
--- a/config/install.yaml
+++ b/config/install.yaml
@@ -1407,7 +1407,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/clastix/capsule:v0.1.0-rc5
+        image: quay.io/clastix/capsule:v0.1.0-rc6
         imagePullPolicy: IfNotPresent
         name: manager
         ports:

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -7,4 +7,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/clastix/capsule
-  newTag: v0.1.0-rc5
+  newTag: v0.1.0-rc6

--- a/hack/create-user-openshift.sh
+++ b/hack/create-user-openshift.sh
@@ -65,6 +65,7 @@ kind: CertificateSigningRequest
 metadata:
   name: ${USER}-${TENANT}
 spec:
+  signerName: kubernetes.io/kube-apiserver-client
   groups:
   - system:authenticated
   request: $(cat ${TMPDIR}/${USER}-${TENANT}.csr | base64 | tr -d '\n')

--- a/hack/create-user.sh
+++ b/hack/create-user.sh
@@ -60,6 +60,7 @@ kind: CertificateSigningRequest
 metadata:
   name: ${USER}-${TENANT}
 spec:
+  signerName: kubernetes.io/kube-apiserver-client
   groups:
   - system:authenticated
   request: $(cat ${TMPDIR}/${USER}-${TENANT}.csr | base64 | tr -d '\n')


### PR DESCRIPTION
Update of `CertificateSigningRequest` API from `v1beta1` to `v1` requires the `spec.signerName` field to be specified.
Close #385

