### PR TITLE
fix: deleting Pods upon TLS update for HA installations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Current Operator version
-VERSION ?= $$(git describe --abbrev=0 --tags)
+VERSION ?= $$(git describe --abbrev=0 --tags --match "v*")
 
 # Default bundle image tag
 BUNDLE_IMG ?= quay.io/clastix/capsule:$(VERSION)-bundle


### PR DESCRIPTION
Closes #410.

Feedback about the issue and proposed solution would be great, @MaxFedotov @bsctl.