### PR TITLE
Tenant Ownership documentation

### DIFF
--- a/docs/operator/use-cases/overview.md
+++ b/docs/operator/use-cases/overview.md
@@ -23,6 +23,7 @@ Use Capsule to address any of the following scenarios:
 * [Onboard Tenants](./onboarding.md)
 * [Create Namespaces](./create-namespaces.md)
 * [Assign Permissions](./permissions.md)
+* [Tenant Ownership](./ownership.md)
 * [Enforce Resources Quotas and Limits](./resources-quota-limits.md)
 * [Enforce Pod Priority Classes](./pod-priority-classes.md)
 * [Assign specific Node Pools](./nodes-pool.md)

--- a/docs/operator/use-cases/ownership.md
+++ b/docs/operator/use-cases/ownership.md
@@ -1,0 +1,64 @@
+# Tenant Ownership
+
+## OIDC Prefix 
+
+The Kube API Server might have oidc prefix flags set. Make sure include those prefixes when declaring tenant owners. The prefixes are always appended for each group or user (depending on the configuration). So even if your token originally looks like this coming from the IDP:
+
+``` 
+"users_groups": [
+  "capsule.clastix.io"
+]
+```
+
+Assuming you have these flags set on your Kube API Server:
+
+```
+...
+    - --oidc-username-prefix=idp_
+    - --oidc-groups-prefix=idp_
+```
+
+You need to prepend the prefix in your tenant configuration:
+
+```
+apiVersion: capsule.clastix.io/v1alpha1
+kind: CapsuleConfiguration
+metadata:
+  name: default
+spec:
+  userGroups:
+    - idp_capsule.clastix.io
+```
+
+Same for tenant Owners:
+
+```
+apiVersion: capsule.clastix.io/v1beta1
+kind: Tenant
+metadata:
+  name: oil
+spec:
+  owners:
+    - kind: Group
+      name: idp_kubernetes/applications
+    - kind: User
+      name: idp_Bob
+```
+
+[Read More](https://kubernetes.io/docs/reference/access-authn-authz/authentication/)
+
+
+## ServiceAccount 
+
+You can delegate the ownership of a tenant to a ServiceAccount. Make sure to correctly reference the serviceAccount according to the pattern `{ServiceAccountName}:{ServiceAccountNamespace}`. Make sure to include the `:` which splits the the name of the serviceAccount with it's namespace:
+
+``` 
+apiVersion: capsule.clastix.io/v1beta1
+kind: Tenant
+metadata:
+  name: oil
+spec:
+  owners:
+    - kind: ServiceAccount
+      name: system:serviceaccount:default
+```


### PR DESCRIPTION
Signed-off-by: Oliver Bähler <oliverbaehler@hotmail.com>

I have added some documentation about Tenant Ownership regarding OIDC and ServiceAccounts (Since I haven't found it anywhere else in the documentation). I don't know if it's helpful, but it would have spared me some hours if I knew these things.. :) 

Maybe we could also move the part from the Main README (https://github.com/clastix/capsule/blob/master/README.md#tenant-owners) to this section and the just reference it. So that everything is in one place.

Have you thought about releasing the documentation via GitHub pages? Might be neat too and I could contribute a draft for that.