### PR TITLE
jq installation checking

### DIFF
--- a/hack/create-user.sh
+++ b/hack/create-user.sh
@@ -22,6 +22,12 @@ if [[ ! -x "$(command -v kubectl)" ]]; then
     exit 1
 fi
 
+# Check if jq is installed
+if [[ ! -x "$(command -v jq)" ]]; then
+    echo "Error: jq not found"
+    exit 1
+fi
+
 USER=$1
 TENANT=$2
 GROUP=$3


### PR DESCRIPTION
<!--
# General contribution criteria

Thanks for spending some time for improving and fixing Capsule!

We're still working on the outline of the contribution guidelines but we're
following ourselves these points:

- reference a previously opened issue: https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls#issues-and-pull-requests 
- including a sentence or two in the commit description for the
  changelog/release notes
- splitting changes into several and documented small commits
- limit the git subject to 50 characters and write as the continuation of the
  sentence "If applied, this commit will ..."
- explain what and why in the body, if more than a trivial change, wrapping at
  72 characters

If you have any issue or question, reach out us!
https://clastix.slack.com >>> #capsule channel 
-->

This PR will try to fix the issue described over [here](https://github.com/clastix/capsule/issues/418).
It will add the `jq` installation checking to the `hack/create_user.sh` script