### PR TITLE
feat(helm): find kubectl tag from server version

### DIFF
--- a/charts/capsule/templates/_helpers.tpl
+++ b/charts/capsule/templates/_helpers.tpl
@@ -95,7 +95,12 @@ Create the proxy fully-qualified Docker image to use
 Create the jobs fully-qualified Docker image to use
 */}}
 {{- define "capsule.jobsFullyQualifiedDockerImage" -}}
+{{- if .Values.jobs.image.tag }}
 {{- printf "%s:%s" .Values.jobs.image.repository .Values.jobs.image.tag -}}
+{{- else }}
+{{- $kubeversion := print "v" .Capabilities.KubeVersion.Major "." .Capabilities.KubeVersion.Minor -}}
+{{- printf "%s:%s" .Values.jobs.image.repository $kubeversion -}}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/capsule/values.yaml
+++ b/charts/capsule/values.yaml
@@ -41,7 +41,7 @@ jobs:
   image:
     repository: quay.io/clastix/kubectl
     pullPolicy: IfNotPresent
-    tag: "v1.20.7"
+    tag: ""
 imagePullSecrets: []
 serviceAccount:
   create: true


### PR DESCRIPTION
Closes #462

if applied, this commit removes the static kubectl client tag and will use a dynamic tag based on the cluster version.

- it'll use the last tag of the matching "minor"
- it is always possible to override the value

this PR remains temporarily in draft, waiting for changes to the push logic of clastix/kubectl repository