### PR TITLE
release(fix) : duplicate release for helm chart

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -6,9 +6,6 @@ on:
     tags: [ "helm-v*" ]
   pull_request:
     branches: [ "*" ]
-  create:
-    branches: [ "*" ]
-    tags: [ "helm-v*" ]
 
 jobs:
   lint:


### PR DESCRIPTION
this commit remote helm release workflow trigger on create which triggers duplicate event as push

fixes: #459

<!--
# General contribution criteria

Thanks for spending some time for improving and fixing Capsule!

We're still working on the outline of the contribution guidelines but we're
following ourselves these points:

- reference a previously opened issue: https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls#issues-and-pull-requests 
- including a sentence or two in the commit description for the
  changelog/release notes
- splitting changes into several and documented small commits
- limit the git subject to 50 characters and write as the continuation of the
  sentence "If applied, this commit will ..."
- explain what and why in the body, if more than a trivial change, wrapping at
  72 characters

If you have any issue or question, reach out us!
https://clastix.slack.com >>> #capsule channel 
-->
