### PR TITLE
Limiting the amount of Custom Resource instances deployed in a Tenant

### DIFF
--- a/api/v1beta1/custom_resource_quota.go
+++ b/api/v1beta1/custom_resource_quota.go
@@ -1,0 +1,47 @@
+// Copyright 2020-2021 Clastix Labs
+// SPDX-License-Identifier: Apache-2.0
+
+package v1beta1
+
+import (
+	"fmt"
+	"strconv"
+)
+
+const (
+	ResourceQuotaAnnotationPrefix = "quota.resources.capsule.clastix.io"
+	ResourceUsedAnnotationPrefix  = "used.resources.capsule.clastix.io"
+)
+
+func UsedAnnotationForResource(kindGroup string) string {
+	return fmt.Sprintf("%s/%s", ResourceUsedAnnotationPrefix, kindGroup)
+}
+
+func LimitAnnotationForResource(kindGroup string) string {
+	return fmt.Sprintf("%s/%s", ResourceQuotaAnnotationPrefix, kindGroup)
+}
+
+func GetUsedResourceFromTenant(tenant Tenant, kindGroup string) (int64, error) {
+	usedStr, ok := tenant.GetAnnotations()[UsedAnnotationForResource(kindGroup)]
+	if !ok {
+		usedStr = "0"
+	}
+
+	used, _ := strconv.ParseInt(usedStr, 10, 10)
+
+	return used, nil
+}
+
+func GetLimitResourceFromTenant(tenant Tenant, kindGroup string) (int64, error) {
+	limitStr, ok := tenant.GetAnnotations()[LimitAnnotationForResource(kindGroup)]
+	if !ok {
+		return 0, fmt.Errorf("resource %s is not limited for the current tenant", kindGroup)
+	}
+
+	limit, err := strconv.ParseInt(limitStr, 10, 10)
+	if err != nil {
+		return 0, fmt.Errorf("resource %s limit cannot be parsed, %w", kindGroup, err)
+	}
+
+	return limit, nil
+}

--- a/controllers/tenant/manager.go
+++ b/controllers/tenant/manager.go
@@ -9,6 +9,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -20,9 +21,10 @@ import (
 
 type Manager struct {
 	client.Client
-	Log      logr.Logger
-	Scheme   *runtime.Scheme
-	Recorder record.EventRecorder
+	Log        logr.Logger
+	Scheme     *runtime.Scheme
+	Recorder   record.EventRecorder
+	RESTConfig *rest.Config
 }
 
 func (r *Manager) SetupWithManager(mgr ctrl.Manager) error {
@@ -52,6 +54,12 @@ func (r Manager) Reconcile(ctx context.Context, request ctrl.Request) (result ct
 	// Ensuring the Tenant Status
 	if err = r.updateTenantStatus(instance); err != nil {
 		r.Log.Error(err, "Cannot update Tenant status")
+		return
+	}
+
+	r.Log.Info("Ensuring limit resources count is updated")
+	if err = r.syncCustomResourceQuotaUsages(ctx, instance); err != nil {
+		r.Log.Error(err, "Cannot count limited resources")
 		return
 	}
 

--- a/controllers/tenant/resourcequotas_quota.go
+++ b/controllers/tenant/resourcequotas_quota.go
@@ -1,0 +1,122 @@
+package tenant
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"golang.org/x/sync/errgroup"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/util/retry"
+
+	capsulev1beta1 "github.com/clastix/capsule/api/v1beta1"
+)
+
+func (r *Manager) syncCustomResourceQuotaUsages(ctx context.Context, tenant *capsulev1beta1.Tenant) error {
+	type resource struct {
+		kind    string
+		group   string
+		version string
+	}
+
+	var resourceList []resource
+
+	for k := range tenant.GetAnnotations() {
+		if !strings.HasPrefix(k, capsulev1beta1.ResourceQuotaAnnotationPrefix) {
+			continue
+		}
+
+		parts := strings.Split(k, "/")
+		if len(parts) != 2 {
+			r.Log.Info("non well-formed Resource Limit annotation", "key", k)
+
+			continue
+		}
+
+		parts = strings.Split(parts[1], "_")
+
+		if len(parts) != 2 {
+			r.Log.Info("non well-formed Resource Limit annotation, cannot retrieve version", "key", k)
+
+			continue
+		}
+
+		groupKindParts := strings.Split(parts[0], ".")
+		if len(groupKindParts) < 2 {
+			r.Log.Info("non well-formed Resource Limit annotation, cannot retrieve kind and group", "key", k)
+
+			continue
+		}
+
+		resourceList = append(resourceList, resource{
+			kind:    groupKindParts[0],
+			group:   strings.Join(groupKindParts[1:], "."),
+			version: parts[1],
+		})
+	}
+
+	errGroup := new(errgroup.Group)
+
+	usedMap := make(map[string]int)
+
+	defer func() {
+		for gvk, used := range usedMap {
+			err := retry.RetryOnConflict(retry.DefaultBackoff, func() (retryErr error) {
+				tnt := &capsulev1beta1.Tenant{}
+				if retryErr = r.Client.Get(ctx, types.NamespacedName{Name: tenant.GetName()}, tnt); retryErr != nil {
+					return
+				}
+
+				if tnt.GetAnnotations() == nil {
+					tnt.Annotations = make(map[string]string)
+				}
+
+				tnt.Annotations[capsulev1beta1.UsedAnnotationForResource(gvk)] = fmt.Sprintf("%d", used)
+
+				return r.Client.Update(ctx, tnt)
+			})
+			if err != nil {
+				r.Log.Error(err, "cannot update custom Resource Quota", "GVK", gvk)
+			}
+		}
+	}()
+
+	for _, item := range resourceList {
+		res := item
+
+		errGroup.Go(func() (scopeErr error) {
+			dynamicClient := dynamic.NewForConfigOrDie(r.RESTConfig)
+
+			for _, ns := range tenant.Status.Namespaces {
+				var list *unstructured.UnstructuredList
+
+				list, scopeErr = dynamicClient.Resource(schema.GroupVersionResource{Group: res.group, Version: res.version, Resource: res.kind}).List(ctx, metav1.ListOptions{
+					FieldSelector: fmt.Sprintf("metadata.namespace==%s", ns),
+				})
+				if scopeErr != nil {
+					return scopeErr
+				}
+
+				key := fmt.Sprintf("%s.%s_%s", res.kind, res.group, res.version)
+
+				if _, ok := usedMap[key]; !ok {
+					usedMap[key] = 0
+				}
+
+				usedMap[key] += len(list.Items)
+			}
+
+			return
+		})
+	}
+
+	if err := errGroup.Wait(); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/e2e/custom_resource_quota_test.go
+++ b/e2e/custom_resource_quota_test.go
@@ -1,0 +1,156 @@
+//go:build e2e
+// +build e2e
+
+// Copyright 2020-2021 Clastix Labs
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes/scheme"
+
+	capsulev1beta1 "github.com/clastix/capsule/api/v1beta1"
+)
+
+var _ = Describe("when Tenant limits custom Resource Quota", func() {
+	tnt := &capsulev1beta1.Tenant{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "limiting-resources",
+			Annotations: map[string]string{
+				"quota.resources.capsule.clastix.io/foos.test.clastix.io_v1": "3",
+			},
+		},
+		Spec: capsulev1beta1.TenantSpec{
+			Owners: capsulev1beta1.OwnerListSpec{
+				{
+					Name: "resource",
+					Kind: "User",
+				},
+			},
+		},
+	}
+
+	crd := &v1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "foos.test.clastix.io",
+		},
+		Spec: v1.CustomResourceDefinitionSpec{
+			Group: "test.clastix.io",
+			Names: v1.CustomResourceDefinitionNames{
+				Kind:     "Foo",
+				ListKind: "FooList",
+				Plural:   "foos",
+				Singular: "foo",
+			},
+			Scope: v1.NamespaceScoped,
+			Versions: []v1.CustomResourceDefinitionVersion{
+				{
+					Name:    "v1",
+					Served:  true,
+					Storage: true,
+					Schema: &v1.CustomResourceValidation{
+						OpenAPIV3Schema: &v1.JSONSchemaProps{
+							Type: "object",
+							Properties: map[string]v1.JSONSchemaProps{
+								"apiVersion": {
+									Type: "string",
+								},
+								"kind": {
+									Type: "string",
+								},
+								"metadata": {
+									Type: "object",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	JustBeforeEach(func() {
+		utilruntime.Must(v1.AddToScheme(scheme.Scheme))
+
+		EventuallyCreation(func() error {
+			return k8sClient.Create(context.TODO(), crd)
+		}).Should(Succeed())
+
+		EventuallyCreation(func() error {
+			return k8sClient.Create(context.TODO(), tnt)
+		}).Should(Succeed())
+	})
+
+	JustAfterEach(func() {
+		Expect(k8sClient.Delete(context.TODO(), crd)).Should(Succeed())
+
+		Expect(k8sClient.Delete(context.TODO(), tnt)).Should(Succeed())
+	})
+
+	It("should block resources in overflow", func() {
+		dynamicClient := dynamic.NewForConfigOrDie(cfg)
+
+		for _, i := range []int{1, 2, 3} {
+			ns := NewNamespace(fmt.Sprintf("resource-ns-%d", i))
+
+			NamespaceCreation(ns, tnt.Spec.Owners[0], defaultTimeoutInterval).Should(Succeed())
+			TenantNamespaceList(tnt, defaultTimeoutInterval).Should(ContainElement(ns.GetName()))
+
+			obj := &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": fmt.Sprintf("%s/%s", crd.Spec.Group, crd.Spec.Versions[0].Name),
+					"kind":       crd.Spec.Names.Kind,
+					"metadata": map[string]interface{}{
+						"name": fmt.Sprintf("resource-%d", i),
+					},
+				},
+			}
+
+			EventuallyCreation(func() (err error) {
+				_, err = dynamicClient.Resource(schema.GroupVersionResource{Group: crd.Spec.Group, Version: crd.Spec.Versions[0].Name, Resource: crd.Spec.Names.Plural}).Namespace(ns.GetName()).Create(context.Background(), obj, metav1.CreateOptions{})
+				return
+			}).ShouldNot(HaveOccurred())
+		}
+
+		for _, i := range []int{1, 2, 3} {
+			ns := NewNamespace(fmt.Sprintf("resource-ns-%d", i))
+
+			obj := &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": fmt.Sprintf("%s/%s", crd.Spec.Group, crd.Spec.Versions[0].Name),
+					"kind":       crd.Spec.Names.Kind,
+					"metadata": map[string]interface{}{
+						"name": fmt.Sprintf("fail-%d", i),
+					},
+				},
+			}
+
+			EventuallyCreation(func() (err error) {
+				_, err = dynamicClient.Resource(schema.GroupVersionResource{Group: crd.Spec.Group, Version: crd.Spec.Versions[0].Name, Resource: crd.Spec.Names.Plural}).Namespace(ns.GetName()).Create(context.Background(), obj, metav1.CreateOptions{})
+
+				return
+			}).Should(HaveOccurred())
+		}
+
+		Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: tnt.GetName()}, tnt)).ShouldNot(HaveOccurred())
+
+		Eventually(func() bool {
+			limit, _ := HaveKeyWithValue("quota.resources.capsule.clastix.io/foos.test.clastix.io_v1", "3").Match(tnt.GetAnnotations())
+			used, _ := HaveKeyWithValue("used.resources.capsule.clastix.io/foos.test.clastix.io_v1", "3").Match(tnt.GetAnnotations())
+
+			return limit && used
+		}, defaultTimeoutInterval, defaultPollInterval).Should(BeTrue())
+	})
+})

--- a/main.go
+++ b/main.go
@@ -167,10 +167,11 @@ func main() {
 
 	if len(ca.Data) > 0 && len(tls.Data) > 0 {
 		if err = (&tenantcontroller.Manager{
-			Client:   manager.GetClient(),
-			Log:      ctrl.Log.WithName("controllers").WithName("Tenant"),
-			Scheme:   manager.GetScheme(),
-			Recorder: manager.GetEventRecorderFor("tenant-controller"),
+			RESTConfig: manager.GetConfig(),
+			Client:     manager.GetClient(),
+			Log:        ctrl.Log.WithName("controllers").WithName("Tenant"),
+			Scheme:     manager.GetScheme(),
+			Recorder:   manager.GetEventRecorderFor("tenant-controller"),
 		}).SetupWithManager(manager); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "Tenant")
 			os.Exit(1)
@@ -206,7 +207,7 @@ func main() {
 			route.NetworkPolicy(utils.InCapsuleGroups(cfg, networkpolicy.Handler())),
 			route.Tenant(tenant.NameHandler(), tenant.RoleBindingRegexHandler(), tenant.IngressClassRegexHandler(), tenant.StorageClassRegexHandler(), tenant.ContainerRegistryRegexHandler(), tenant.HostnameRegexHandler(), tenant.FreezedEmitter(), tenant.ServiceAccountNameHandler()),
 			route.OwnerReference(utils.InCapsuleGroups(cfg, ownerreference.Handler(cfg))),
-			route.Cordoning(tenant.CordoningHandler(cfg)),
+			route.Cordoning(tenant.CordoningHandler(cfg), tenant.ResourceCounterHandler()),
 			route.Node(utils.InCapsuleGroups(cfg, node.UserMetadataHandler(cfg, kubeVersion))),
 		)
 

--- a/pkg/webhook/tenant/custom_resource_quota.go
+++ b/pkg/webhook/tenant/custom_resource_quota.go
@@ -1,0 +1,151 @@
+// Copyright 2020-2021 Clastix Labs
+// SPDX-License-Identifier: Apache-2.0
+
+package tenant
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	capsulev1beta1 "github.com/clastix/capsule/api/v1beta1"
+	capsulewebhook "github.com/clastix/capsule/pkg/webhook"
+	"github.com/clastix/capsule/pkg/webhook/utils"
+)
+
+type resourceCounterHandler struct {
+	client client.Client
+}
+
+func (r *resourceCounterHandler) InjectClient(c client.Client) error {
+	r.client = c
+
+	return nil
+}
+
+func ResourceCounterHandler() capsulewebhook.Handler {
+	return &resourceCounterHandler{}
+}
+
+func (r *resourceCounterHandler) getTenantName(ctx context.Context, clt client.Client, req admission.Request) (string, error) {
+	tntList := &capsulev1beta1.TenantList{}
+
+	if err := clt.List(ctx, tntList, client.MatchingFieldsSelector{
+		Selector: fields.OneTermEqualSelector(".status.namespaces", req.Namespace),
+	}); err != nil {
+		return "", err
+	}
+
+	if len(tntList.Items) == 0 {
+		return "", nil
+	}
+
+	return tntList.Items[0].GetName(), nil
+}
+
+func (r *resourceCounterHandler) OnCreate(clt client.Client, decoder *admission.Decoder, recorder record.EventRecorder) capsulewebhook.Func {
+	return func(ctx context.Context, req admission.Request) *admission.Response {
+		var tntName string
+
+		var err error
+
+		if tntName, err = r.getTenantName(ctx, clt, req); err != nil {
+			return utils.ErroredResponse(err)
+		}
+
+		if len(tntName) == 0 {
+			return nil
+		}
+
+		kgv := fmt.Sprintf("%s.%s_%s", req.Resource.Resource, req.Resource.Group, req.Resource.Version)
+
+		tnt := &capsulev1beta1.Tenant{}
+
+		var limit int64
+
+		err = retry.RetryOnConflict(retry.DefaultRetry, func() (retryErr error) {
+			if retryErr = clt.Get(ctx, types.NamespacedName{Name: tntName}, tnt); err != nil {
+				return retryErr
+			}
+
+			if limit, retryErr = capsulev1beta1.GetLimitResourceFromTenant(*tnt, kgv); retryErr != nil {
+				return nil
+			}
+			used, _ := capsulev1beta1.GetUsedResourceFromTenant(*tnt, kgv)
+
+			if used >= limit {
+				return NewCustomResourceQuotaError(kgv, limit)
+			}
+
+			tnt.Annotations[capsulev1beta1.UsedAnnotationForResource(kgv)] = fmt.Sprintf("%d", used+1)
+
+			return clt.Update(ctx, tnt)
+		})
+		if err != nil {
+			if _, ok := err.(*customResourceQuotaError); ok {
+				recorder.Eventf(tnt, corev1.EventTypeWarning, "ResourceQuota", "Resource %s/%s in API group %s cannot be created, limit usage of %d has been reached", req.Namespace, req.Name, kgv, limit)
+			}
+
+			return utils.ErroredResponse(err)
+		}
+
+		return nil
+	}
+}
+
+func (r *resourceCounterHandler) OnDelete(clt client.Client, decoder *admission.Decoder, recorder record.EventRecorder) capsulewebhook.Func {
+	return func(ctx context.Context, req admission.Request) *admission.Response {
+		var tntName string
+
+		var err error
+
+		if tntName, err = r.getTenantName(ctx, clt, req); err != nil {
+			return utils.ErroredResponse(err)
+		}
+
+		if len(tntName) == 0 {
+			return nil
+		}
+
+		kgv := fmt.Sprintf("%s.%s_%s", req.Resource.Resource, req.Resource.Group, req.Resource.Version)
+
+		err = retry.RetryOnConflict(retry.DefaultRetry, func() (retryErr error) {
+			tnt := &capsulev1beta1.Tenant{}
+			if retryErr = clt.Get(ctx, types.NamespacedName{Name: tntName}, tnt); err != nil {
+				return
+			}
+
+			if tnt.Annotations == nil {
+				return
+			}
+
+			if _, ok := tnt.Annotations[capsulev1beta1.UsedAnnotationForResource(kgv)]; !ok {
+				return
+			}
+
+			used, _ := capsulev1beta1.GetUsedResourceFromTenant(*tnt, kgv)
+
+			tnt.Annotations[capsulev1beta1.UsedAnnotationForResource(kgv)] = fmt.Sprintf("%d", used-1)
+
+			return clt.Update(ctx, tnt)
+		})
+		if err != nil {
+			return utils.ErroredResponse(err)
+		}
+
+		return nil
+	}
+}
+
+func (r *resourceCounterHandler) OnUpdate(client client.Client, decoder *admission.Decoder, recorder record.EventRecorder) capsulewebhook.Func {
+	return func(ctx context.Context, req admission.Request) *admission.Response {
+		return nil
+	}
+}

--- a/pkg/webhook/tenant/custom_resource_quota_errors.go
+++ b/pkg/webhook/tenant/custom_resource_quota_errors.go
@@ -1,0 +1,22 @@
+// Copyright 2020-2021 Clastix Labs
+// SPDX-License-Identifier: Apache-2.0
+
+package tenant
+
+import "fmt"
+
+type customResourceQuotaError struct {
+	kindGroup string
+	limit     int64
+}
+
+func NewCustomResourceQuotaError(kindGroup string, limit int64) error {
+	return &customResourceQuotaError{
+		kindGroup: kindGroup,
+		limit:     limit,
+	}
+}
+
+func (r customResourceQuotaError) Error() string {
+	return fmt.Sprintf("resource %s has reached quota limit of %d items", r.kindGroup, r.limit)
+}


### PR DESCRIPTION
Closes #365.

```yaml
apiVersion: capsule.clastix.io/v1beta1
kind: Tenant
metadata:
  name: oil
  annotations:
    quota.resources.capsule.clastix.io/mysqls.databases.acme.corp_v1: "3"
spec:
  owners:
  - name: alice
    kind: User
```

With this special annotation in the Tenant manifest, a Cluster Administrator can limit the amount of resources `MySQL` in the API Group `databases.acme.corp/v1` in all the Namespaces belonging to the Tenant.

> Obviously, Alice must have granted permissions to manage these Custom Resources using `additionalRoleBindings` Tenant specification key, and this feature can work only for Namespaced-scope resources.