### PR TITLE
fix: yaml installer should use namespace selector for pods webhook

### DIFF
--- a/config/install.yaml
+++ b/config/install.yaml
@@ -1614,6 +1614,10 @@ webhooks:
       path: /pods
   failurePolicy: Fail
   name: pods.capsule.clastix.io
+  namespaceSelector:
+    matchExpressions:
+    - key: capsule.clastix.io/tenant
+      operator: Exists
   rules:
   - apiGroups:
     - ""

--- a/config/webhook/patch_ns_selector.yaml
+++ b/config/webhook/patch_ns_selector.yaml
@@ -23,6 +23,12 @@
       - key: capsule.clastix.io/tenant
         operator: Exists
 - op: add
+  path: /webhooks/5/namespaceSelector
+  value:
+    matchExpressions:
+      - key: capsule.clastix.io/tenant
+        operator: Exists
+- op: add
   path: /webhooks/6/namespaceSelector
   value:
     matchExpressions:


### PR DESCRIPTION
Closes #483.