### PR TITLE
fix: starting all controller only when certificates are generated

### DIFF
--- a/controllers/secret/ca.go
+++ b/controllers/secret/ca.go
@@ -189,7 +189,7 @@ func (r CAReconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl
 		tls := &corev1.Secret{}
 		err = r.Get(ctx, types.NamespacedName{
 			Namespace: r.Namespace,
-			Name:      tlsSecretName,
+			Name:      TLSSecretName,
 		}, tls)
 		if err != nil {
 			r.Log.Error(err, "Capsule TLS Secret missing")

--- a/controllers/secret/const.go
+++ b/controllers/secret/const.go
@@ -8,5 +8,5 @@ const (
 	privateKeySecretKey = "tls.key"
 
 	CASecretName  = "capsule-ca"
-	tlsSecretName = "capsule-tls"
+	TLSSecretName = "capsule-tls"
 )

--- a/controllers/secret/tls.go
+++ b/controllers/secret/tls.go
@@ -33,7 +33,7 @@ type TLSReconciler struct {
 
 func (r *TLSReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&corev1.Secret{}, forOptionPerInstanceName(tlsSecretName)).
+		For(&corev1.Secret{}, forOptionPerInstanceName(TLSSecretName)).
 		Complete(r)
 }
 
@@ -112,7 +112,7 @@ func (r TLSReconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctr
 		return reconcile.Result{}, err
 	}
 
-	if instance.Name == tlsSecretName && res == controllerutil.OperationResultUpdated {
+	if instance.Name == TLSSecretName && res == controllerutil.OperationResultUpdated {
 		r.Log.Info("Capsule TLS certificates has been updated, Controller pods must be restarted to load new certificate")
 
 		hostname, _ := os.Hostname()


### PR DESCRIPTION
Closes #440.

This is going to solve the issue when upgrading Capsule <v0.1.0 to >=v0.1.0: due to a resource reflector many warnings were polluting the reconciliation loop and causing unmarshaling errors.

Additionally, just the CA secret was checked before starting the Operator, when also the TLS is requested for the webhooks, along with the `/convert` one that is used for the CR version conversion.
