### PR TITLE
chore(description): description for limitRanges and update doc

### DIFF
--- a/api/v1beta1/tenant_types.go
+++ b/api/v1beta1/tenant_types.go
@@ -21,11 +21,11 @@ type TenantSpec struct {
 	IngressOptions IngressOptions `json:"ingressOptions,omitempty"`
 	// Specifies the trusted Image Registries assigned to the Tenant. Capsule assures that all Pods resources created in the Tenant can use only one of the allowed trusted registries. Optional.
 	ContainerRegistries *AllowedListSpec `json:"containerRegistries,omitempty"`
-	// Specifies the label to control the placement of pods on a given pool of worker nodes. All namesapces created within the Tenant will have the node selector annotation. This annotation tells the Kubernetes scheduler to place pods on the nodes having the selector label. Optional.
+	// Specifies the label to control the placement of pods on a given pool of worker nodes. All namespaces created within the Tenant will have the node selector annotation. This annotation tells the Kubernetes scheduler to place pods on the nodes having the selector label. Optional.
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 	// Specifies the NetworkPolicies assigned to the Tenant. The assigned NetworkPolicies are inherited by any namespace created in the Tenant. Optional.
 	NetworkPolicies NetworkPolicySpec `json:"networkPolicies,omitempty"`
-	// Specifies the NetworkPolicies assigned to the Tenant. The assigned NetworkPolicies are inherited by any namespace created in the Tenant. Optional.
+	// Specifies the resource min/max usage restrictions to the Tenant. The assigned values are inherited by any namespace created in the Tenant. Optional.
 	LimitRanges LimitRangesSpec `json:"limitRanges,omitempty"`
 	// Specifies a list of ResourceQuota resources assigned to the Tenant. The assigned values are inherited by any namespace created in the Tenant. The Capsule operator aggregates ResourceQuota at Tenant level, so that the hard quota is never crossed for the given Tenant. This permits the Tenant owner to consume resources in the Tenant regardless of the namespace. Optional.
 	ResourceQuota ResourceQuotaSpec `json:"resourceQuotas,omitempty"`

--- a/config/crd/bases/capsule.clastix.io_tenants.yaml
+++ b/config/crd/bases/capsule.clastix.io_tenants.yaml
@@ -697,7 +697,7 @@ spec:
                     type: string
                 type: object
               limitRanges:
-                description: Specifies the NetworkPolicies assigned to the Tenant. The assigned NetworkPolicies are inherited by any namespace created in the Tenant. Optional.
+                description: Specifies the resource min/max usage restrictions to the Tenant. The assigned values are inherited by any namespace created in the Tenant. Optional.
                 properties:
                   items:
                     items:
@@ -1055,7 +1055,7 @@ spec:
               nodeSelector:
                 additionalProperties:
                   type: string
-                description: Specifies the label to control the placement of pods on a given pool of worker nodes. All namesapces created within the Tenant will have the node selector annotation. This annotation tells the Kubernetes scheduler to place pods on the nodes having the selector label. Optional.
+                description: Specifies the label to control the placement of pods on a given pool of worker nodes. All namespaces created within the Tenant will have the node selector annotation. This annotation tells the Kubernetes scheduler to place pods on the nodes having the selector label. Optional.
                 type: object
               owners:
                 description: Specifies the owners of the Tenant. Mandatory.

--- a/config/install.yaml
+++ b/config/install.yaml
@@ -769,7 +769,7 @@ spec:
                     type: string
                 type: object
               limitRanges:
-                description: Specifies the NetworkPolicies assigned to the Tenant. The assigned NetworkPolicies are inherited by any namespace created in the Tenant. Optional.
+                description: Specifies the resource min/max usage restrictions to the Tenant. The assigned values are inherited by any namespace created in the Tenant. Optional.
                 properties:
                   items:
                     items:
@@ -1127,7 +1127,7 @@ spec:
               nodeSelector:
                 additionalProperties:
                   type: string
-                description: Specifies the label to control the placement of pods on a given pool of worker nodes. All namesapces created within the Tenant will have the node selector annotation. This annotation tells the Kubernetes scheduler to place pods on the nodes having the selector label. Optional.
+                description: Specifies the label to control the placement of pods on a given pool of worker nodes. All namespaces created within the Tenant will have the node selector annotation. This annotation tells the Kubernetes scheduler to place pods on the nodes having the selector label. Optional.
                 type: object
               owners:
                 description: Specifies the owners of the Tenant. Mandatory.

--- a/docs/content/general/references.md
+++ b/docs/content/general/references.md
@@ -73,9 +73,8 @@ FIELDS:
      IngressClass. Optional.
 
    limitRanges  <Object>
-     Specifies the NetworkPolicies assigned to the Tenant. The assigned
-     NetworkPolicies are inherited by any namespace created in the Tenant.
-     Optional.
+     Specifies the resource min/max usage restrictions to the Tenant. The assigned
+     values are inherited by any namespace created in the Tenant. Optional.
 
    namespaceOptions     <Object>
      Specifies options for the Namespaces, such as additional metadata or


### PR DESCRIPTION
Signed-off-by: gkarthiks <github.gkarthiks@gmail.com>

Provides the right description for the `limitRanges` in TenantSpec, in turn applying that to the generated CRDs and updating the reference document.