### PR TITLE
fix Makefile for building local binary with make manager

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,8 +40,8 @@ test: generate manifests
 	go test ./... -coverprofile cover.out
 
 # Build manager binary
-manager: generate fmt vet
-	go build -o bin/manager main.go
+manager: generate golint
+	go build -o bin/manager
 
 # Run against the configured Kubernetes cluster in ~/.kube/config
 run: generate manifests


### PR DESCRIPTION
I tried to run `make manager` to make sure I can build capsure locally.

-> First attempt

```
make: *** No rule to make target `fmt', needed by `manager'.  Stop.
```

fmt and vet rules were missing. I added fmt and vet rules(as part of this commit)

-> Second attempt

```
go fmt ./...
go vet ./...
go build -o bin/manager main.go
./main.go:65:55: undefined: GitTag
./main.go:65:63: undefined: GitCommit
./main.go:65:74: undefined: GitDirty
./main.go:66:46: undefined: GitRepo
./main.go:67:46: undefined: BuildTime
make: *** [manager] Error 2
```

This is due to  passing main.go to build, while the package has multiple files
`main.go` and `version.go`, the missing symbols are in `version.go`

I fixed this by building root package. And now go is happy!

-> Third attempt

```
go fmt ./...
go vet ./...
go build -o bin/manager
```

<!--
# General contribution criteria

Thanks for spending some time for improving and fixing Capsule!

We're still working on the outline of the contribution guidelines but we're
following ourselves these points:

- reference a previously opened issue: https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls#issues-and-pull-requests 
- including a sentence or two in the commit description for the
  changelog/release notes
- splitting changes into several and documented small commits
- limit the git subject to 50 characters and write as the continuation of the
  sentence "If applied, this commit will ..."
- explain what and why in the body, if more than a trivial change, wrapping at
  72 characters

If you have any issue or question, reach out us!
https://clastix.slack.com >>> #capsule channel 
-->
