### PR TITLE
support cert-manager for generating tls and ca

### DIFF
--- a/charts/capsule/Chart.yaml
+++ b/charts/capsule/Chart.yaml
@@ -21,7 +21,7 @@ sources:
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.1.8
+version: 0.1.9
 
 # This is the version number of the application being deployed.
 # This version number should be incremented each time you make changes to the application.

--- a/charts/capsule/README.md
+++ b/charts/capsule/README.md
@@ -58,45 +58,46 @@ If you only need to make minor customizations, you can specify them on the comma
 
 Here the values you can override:
 
-Parameter | Description | Default
---- | --- | ---
-`manager.hostNetwork` | Specifies if the container should be started in `hostNetwork` mode. | `false` 
-`manager.options.logLevel` | Set the log verbosity of the controller with a value from 1 to 10.| `4`
+Parameter | Description                                                                                                                             | Default
+--- |-----------------------------------------------------------------------------------------------------------------------------------------| ---
+`manager.hostNetwork` | Specifies if the container should be started in `hostNetwork` mode.                                                                     | `false` 
+`manager.options.logLevel` | Set the log verbosity of the controller with a value from 1 to 10.                                                                      | `4`
 `manager.options.forceTenantPrefix` | Boolean, enforces the Tenant owner, during Namespace creation, to name it using the selected Tenant name as prefix, separated by a dash | `false`
-`manager.options.capsuleUserGroups` | Override the Capsule user groups | `[capsule.clastix.io]`
-`manager.options.protectedNamespaceRegex` | If specified, disallows creation of namespaces matching the passed regexp | `null`
-`manager.image.repository` | Set the image repository of the controller. | `quay.io/clastix/capsule`
-`manager.image.tag` | Overrides the image tag whose default is the chart. `appVersion` | `null`
-`manager.image.pullPolicy` | Set the image pull policy. | `IfNotPresent`
-`manager.livenessProbe` | Configure the liveness probe using Deployment probe spec | `GET :10080/healthz`
-`manager.readinessProbe` | Configure the readiness probe using Deployment probe spec | `GET :10080/readyz`
-`manager.resources.requests/cpu` | Set the CPU requests assigned to the controller. | `200m`
-`manager.resources.requests/memory` | Set the memory requests assigned to the controller. | `128Mi`
-`manager.resources.limits/cpu` | Set the CPU limits assigned to the controller. | `200m`
-`manager.resources.limits/cpu` | Set the memory limits assigned to the controller. | `128Mi`
-`mutatingWebhooksTimeoutSeconds` | Timeout in seconds for mutating webhooks. | `30`
-`validatingWebhooksTimeoutSeconds` | Timeout in seconds for validating webhooks. | `30`
-`webhooks` | Additional configuration for capsule webhooks. |
-`imagePullSecrets` | Configuration for `imagePullSecrets` so that you can use a private images registry. | `[]`
-`serviceAccount.create` | Specifies whether a service account should be created. | `true`
-`serviceAccount.annotations` | Annotations to add to the service account. | `{}`
-`serviceAccount.name` | The name of the service account to use. If not set and `serviceAccount.create=true`, a name is generated using the fullname template | `capsule`
-`podAnnotations` | Annotations to add to the Capsule pod. | `{}`
-`priorityClassName` | Set the priority class name of the Capsule pod. | `null`
-`nodeSelector` | Set the node selector for the Capsule pod. | `{}`
-`tolerations` | Set list of tolerations for the Capsule pod. | `[]`
-`replicaCount` | Set the replica count for Capsule pod. | `1`
-`affinity` | Set affinity rules for the Capsule pod. | `{}`
-`podSecurityPolicy.enabled` | Specify if a Pod Security Policy must be created. | `false`
-`serviceMonitor.enabled` | Specifies if a service monitor must be created. | `false`
-`serviceMonitor.labels` | Additional labels which will be added to service monitor. | `{}`
-`serviceMonitor.annotations` | Additional annotations which will be added to service monitor. | `{}`
-`serviceMonitor.matchLabels` | Additional matchLabels which will be added to service monitor. | `{}`
-`serviceMonitor.serviceAccount.name` | Specifies service account name for metrics scrape. | `capsule`
-`serviceMonitor.serviceAccount.namespace` | Specifies service account namespace for metrics scrape. | `capsule-system`
-`customLabels` | Additional labels which will be added to all resources created by Capsule helm chart . | `{}`
-`customAnnotations` | Additional annotations which will be added to all resources created by Capsule helm chart . | `{}`
-
+`manager.options.capsuleUserGroups` | Override the Capsule user groups                                                                                                        | `[capsule.clastix.io]`
+`manager.options.protectedNamespaceRegex` | If specified, disallows creation of namespaces matching the passed regexp                                                               | `null`
+`manager.options.enableSecretController` | Boolean, enables apsule secret controller which reconciles TLS and CA secrets for capsule webhooks.                                     | `true`
+`manager.image.repository` | Set the image repository of the controller.                                                                                             | `quay.io/clastix/capsule`
+`manager.image.tag` | Overrides the image tag whose default is the chart. `appVersion`                                                                        | `null`
+`manager.image.pullPolicy` | Set the image pull policy.                                                                                                              | `IfNotPresent`
+`manager.livenessProbe` | Configure the liveness probe using Deployment probe spec                                                                                | `GET :10080/healthz`
+`manager.readinessProbe` | Configure the readiness probe using Deployment probe spec                                                                               | `GET :10080/readyz`
+`manager.resources.requests/cpu` | Set the CPU requests assigned to the controller.                                                                                        | `200m`
+`manager.resources.requests/memory` | Set the memory requests assigned to the controller.                                                                                     | `128Mi`
+`manager.resources.limits/cpu` | Set the CPU limits assigned to the controller.                                                                                          | `200m`
+`manager.resources.limits/cpu` | Set the memory limits assigned to the controller.                                                                                       | `128Mi`
+`mutatingWebhooksTimeoutSeconds` | Timeout in seconds for mutating webhooks.                                                                                               | `30`
+`validatingWebhooksTimeoutSeconds` | Timeout in seconds for validating webhooks.                                                                                             | `30`
+`webhooks` | Additional configuration for capsule webhooks.                                                                                          |
+`imagePullSecrets` | Configuration for `imagePullSecrets` so that you can use a private images registry.                                                     | `[]`
+`serviceAccount.create` | Specifies whether a service account should be created.                                                                                  | `true`
+`serviceAccount.annotations` | Annotations to add to the service account.                                                                                              | `{}`
+`serviceAccount.name` | The name of the service account to use. If not set and `serviceAccount.create=true`, a name is generated using the fullname template    | `capsule`
+`podAnnotations` | Annotations to add to the Capsule pod.                                                                                                  | `{}`
+`priorityClassName` | Set the priority class name of the Capsule pod.                                                                                         | `null`
+`nodeSelector` | Set the node selector for the Capsule pod.                                                                                              | `{}`
+`tolerations` | Set list of tolerations for the Capsule pod.                                                                                            | `[]`
+`replicaCount` | Set the replica count for Capsule pod.                                                                                                  | `1`
+`affinity` | Set affinity rules for the Capsule pod.                                                                                                 | `{}`
+`podSecurityPolicy.enabled` | Specify if a Pod Security Policy must be created.                                                                                       | `false`
+`serviceMonitor.enabled` | Specifies if a service monitor must be created.                                                                                         | `false`
+`serviceMonitor.labels` | Additional labels which will be added to service monitor.                                                                               | `{}`
+`serviceMonitor.annotations` | Additional annotations which will be added to service monitor.                                                                          | `{}`
+`serviceMonitor.matchLabels` | Additional matchLabels which will be added to service monitor.                                                                          | `{}`
+`serviceMonitor.serviceAccount.name` | Specifies service account name for metrics scrape.                                                                                      | `capsule`
+`serviceMonitor.serviceAccount.namespace` | Specifies service account namespace for metrics scrape.                                                                                 | `capsule-system`
+`customLabels` | Additional labels which will be added to all resources created by Capsule helm chart .                                                  | `{}`
+`customAnnotations` | Additional annotations which will be added to all resources created by Capsule helm chart .                                             | `{}`
+`certManager.generateCertificates` | Specifies whether capsule webhooks certificates should be generated using cert-manager.                                                 | `false`
 ## Created resources
 
 This Helm Chart creates the following Kubernetes resources in the release namespace:

--- a/charts/capsule/templates/_helpers.tpl
+++ b/charts/capsule/templates/_helpers.tpl
@@ -67,6 +67,19 @@ ServiceAccount annotations
 
 
 {{/*
+Webhook annotations
+*/}}
+{{- define "capsule.webhookAnnotations" -}}
+{{- if .Values.certManager.generateCertificates -}}
+cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "capsule.fullname" . }}-webhook-cert
+{{- end }}
+{{- if .Values.customAnnotations }}
+{{ toYaml .Values.customAnnotations }}
+{{- end }}
+{{- end }}
+
+
+{{/*
 Create the name of the service account to use
 */}}
 {{- define "capsule.serviceAccountName" -}}
@@ -124,7 +137,11 @@ Create the Capsule Deployment name to use
 Create the Capsule CA Secret name to use
 */}}
 {{- define "capsule.secretCaName" -}}
+{{- if .Values.certManager.generateCertificates }}
+{{- printf "%s-tls" (include "capsule.fullname" .) -}}
+{{- else }}
 {{- printf "%s-ca" (include "capsule.fullname" .) -}}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/capsule/templates/ca.yaml
+++ b/charts/capsule/templates/ca.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.certManager.generateCertificates }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -8,3 +9,4 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   name: {{ include "capsule.secretCaName" . }}
+{{- end }}

--- a/charts/capsule/templates/certificate.yaml
+++ b/charts/capsule/templates/certificate.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.certManager.generateCertificates }}
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ include "capsule.fullname" . }}-webhook-selfsigned
+  labels:
+    {{- include "capsule.labels" . | nindent 4 }}
+  {{- with .Values.customAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "capsule.fullname" . }}-webhook-cert
+  labels:
+    {{- include "capsule.labels" . | nindent 4 }}
+  {{- with .Values.customAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  dnsNames:
+  - {{ include "capsule.fullname" . }}-webhook-service.{{ .Release.Namespace }}.svc
+  - {{ include "capsule.fullname" . }}-webhook-service.{{ .Release.Namespace }}.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: {{ include "capsule.fullname" . }}-webhook-selfsigned
+  secretName: {{ include "capsule.fullname" . }}-tls
+{{- end }}

--- a/charts/capsule/templates/deployment.yaml
+++ b/charts/capsule/templates/deployment.yaml
@@ -56,6 +56,7 @@ spec:
           - --enable-leader-election
           - --zap-log-level={{ default 4 .Values.manager.options.logLevel }}
           - --configuration-name=default
+          - --enable-secret-controller={{ .Values.manager.options.enableSecretController }}
           image: {{ include "capsule.managerFullyQualifiedDockerImage" . }}
           imagePullPolicy: {{ .Values.manager.image.pullPolicy }}
           env:

--- a/charts/capsule/templates/mutatingwebhookconfiguration.yaml
+++ b/charts/capsule/templates/mutatingwebhookconfiguration.yaml
@@ -4,16 +4,18 @@ metadata:
   name: {{ include "capsule.fullname" . }}-mutating-webhook-configuration
   labels:
     {{- include "capsule.labels" . | nindent 4 }}
-  {{- with .Values.customAnnotations }}
+  {{- if or (.Values.certManager.generateCertificates) (.Values.customAnnotations)  }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+     {{- include "capsule.webhookAnnotations" . | nindent 4 }}
   {{- end }}
 webhooks:
 - admissionReviewVersions:
     - v1
     - v1beta1
   clientConfig:
+{{- if not .Values.certManager.generateCertificates }}
     caBundle: Cg==
+{{- end }}
     service:
       name: {{ include "capsule.fullname" . }}-webhook-service
       namespace: {{ .Release.Namespace }}

--- a/charts/capsule/templates/pre-delete-job.yaml
+++ b/charts/capsule/templates/pre-delete-job.yaml
@@ -1,5 +1,7 @@
 {{- $cmd := printf "kubectl scale deployment -n $NAMESPACE %s --replicas 0 &&" (include "capsule.deploymentName" .) -}}
+{{- if not .Values.certManager.generateCertificates }}
 {{- $cmd = printf "%s kubectl delete secret -n $NAMESPACE %s %s --ignore-not-found &&" $cmd (include "capsule.secretTlsName" .) (include "capsule.secretCaName" .) -}}
+{{- end }}
 {{- $cmd = printf "%s kubectl delete clusterroles.rbac.authorization.k8s.io capsule-namespace-deleter capsule-namespace-provisioner --ignore-not-found &&" $cmd -}}
 {{- $cmd = printf "%s kubectl delete clusterrolebindings.rbac.authorization.k8s.io capsule-namespace-deleter capsule-namespace-provisioner --ignore-not-found" $cmd -}}
 apiVersion: batch/v1

--- a/charts/capsule/templates/validatingwebhookconfiguration.yaml
+++ b/charts/capsule/templates/validatingwebhookconfiguration.yaml
@@ -4,16 +4,18 @@ metadata:
   name: {{ include "capsule.fullname" . }}-validating-webhook-configuration
   labels:
     {{- include "capsule.labels" . | nindent 4 }}
-  {{- with .Values.customAnnotations }}
+  {{- if or (.Values.certManager.generateCertificates) (.Values.customAnnotations)  }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+     {{- include "capsule.webhookAnnotations" . | nindent 4 }}
   {{- end }}
 webhooks:
 - admissionReviewVersions:
     - v1
     - v1beta1
   clientConfig:
+{{- if not .Values.certManager.generateCertificates }}
     caBundle: Cg==
+{{- end }}
     service:
       name: {{ include "capsule.fullname" . }}-webhook-service
       namespace: {{ .Release.Namespace }}
@@ -43,7 +45,9 @@ webhooks:
     - v1
     - v1beta1
   clientConfig:
+{{- if not .Values.certManager.generateCertificates }}
     caBundle: Cg==
+{{- end }}
     service:
       name: {{ include "capsule.fullname" . }}-webhook-service
       namespace: {{ .Release.Namespace }}
@@ -74,7 +78,9 @@ webhooks:
     - v1
     - v1beta1
   clientConfig:
+{{- if not .Values.certManager.generateCertificates }}
     caBundle: Cg==
+{{- end }}
     service:
       name: {{ include "capsule.fullname" . }}-webhook-service
       namespace: {{ .Release.Namespace }}
@@ -103,7 +109,9 @@ webhooks:
     - v1
     - v1beta1
   clientConfig:
+{{- if not .Values.certManager.generateCertificates }}
     caBundle: Cg==
+{{- end }}
     service:
       name: {{ include "capsule.fullname" . }}-webhook-service
       namespace: {{ .Release.Namespace }}
@@ -132,7 +140,9 @@ webhooks:
     - v1
     - v1beta1
   clientConfig:
+{{- if not .Values.certManager.generateCertificates }}
     caBundle: Cg==
+{{- end }}
     service:
       name: {{ include "capsule.fullname" . }}-webhook-service
       namespace: {{ .Release.Namespace }}
@@ -160,7 +170,9 @@ webhooks:
     - v1
     - v1beta1
   clientConfig:
+{{- if not .Values.certManager.generateCertificates }}
     caBundle: Cg==
+{{- end }}
     service:
       name: {{ include "capsule.fullname" . }}-webhook-service
       namespace: {{ .Release.Namespace }}
@@ -186,7 +198,9 @@ webhooks:
     - v1
     - v1beta1
   clientConfig:
+{{- if not .Values.certManager.generateCertificates }}
     caBundle: Cg==
+{{- end }}
     service:
       name: {{ include "capsule.fullname" . }}-webhook-service
       namespace: {{ .Release.Namespace }}
@@ -215,7 +229,9 @@ webhooks:
     - v1
     - v1beta1
   clientConfig:
+{{- if not .Values.certManager.generateCertificates }}
     caBundle: Cg==
+{{- end }}
     service:
       name: {{ include "capsule.fullname" . }}-webhook-service
       namespace: {{ .Release.Namespace }}
@@ -244,7 +260,9 @@ webhooks:
     - v1
     - v1beta1
   clientConfig:
+{{- if not .Values.certManager.generateCertificates }}
     caBundle: Cg==
+{{- end }}
     service:
       name: {{ include "capsule.fullname" . }}-webhook-service
       namespace: {{ .Release.Namespace }}

--- a/charts/capsule/values.yaml
+++ b/charts/capsule/values.yaml
@@ -21,6 +21,7 @@ manager:
     forceTenantPrefix: false
     capsuleUserGroups: ["capsule.clastix.io"]
     protectedNamespaceRegex: ""
+    enableSecretController: true
   livenessProbe:
     httpGet:
       path: /healthz
@@ -60,6 +61,9 @@ replicaCount: 1
 affinity: {}
 podSecurityPolicy:
   enabled: false
+
+certManager:
+  generateCertificates: false
 
 serviceMonitor:
   enabled: false


### PR DESCRIPTION
closes #554 

Added new flag to Capsule `enable-secret-controller`, which enables or disables secretcontroller reconcilers.
added 2 new options to Capsule helm chart:
- `manager.options.enableSecretController` - configures `enable-secret-controller` flag
- `certManager.generateCertificates` - enables cert-manager certificates yaml and other stuff