### PR TITLE
chore(ci): pinning golangci-lint version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v2.3.0
         with:
-          version: latest
+          version: v1.45.2
           only-new-issues: false
           args: --timeout 2m --config .golangci.yml
   diff:


### PR DESCRIPTION
Just ensuring to ping the correct `golangci-lint` version.