### PR TITLE
refactor: sentinel error for running in out of cluster mode

### DIFF
--- a/controllers/tls/errors.go
+++ b/controllers/tls/errors.go
@@ -1,0 +1,10 @@
+// Copyright 2020-2021 Clastix Labs
+// SPDX-License-Identifier: Apache-2.0
+
+package tls
+
+type RunningInOutOfClusterModeError struct{}
+
+func (r RunningInOutOfClusterModeError) Error() string {
+	return "cannot retrieve the leader Pod, probably running in out of the cluster mode"
+}


### PR DESCRIPTION
Closes #594.

With the use of the sentinel error, I can skip the labeling of pods required by the latest changes introduced with #555.

```
2022-06-19T14:31:53.596+0200    INFO    controllers.TLS skipping annotation of Pods for cert-manager    {"Request.Namespace": "capsule-system", "Request.Name": "capsule-tls", "error": "cannot retrieve the leader Pod, probably running in out of the cluster mode"}
```