### PR TITLE
Integration with cert-manager

### DIFF
--- a/api/v1alpha1/capsuleconfiguration_annotations.go
+++ b/api/v1alpha1/capsuleconfiguration_annotations.go
@@ -8,5 +8,5 @@ const (
 	TLSSecretNameAnnotation                  = "capsule.clastix.io/tls-secret-name"
 	MutatingWebhookConfigurationName         = "capsule.clastix.io/mutating-webhook-configuration-name"
 	ValidatingWebhookConfigurationName       = "capsule.clastix.io/validating-webhook-configuration-name"
-	GenerateCertificatesAnnotationName       = "capsule.clastix.io/generate-certificates"
+	EnableTLSConfigurationAnnotationName     = "capsule.clastix.io/enable-tls-configuration"
 )

--- a/charts/capsule/Makefile
+++ b/charts/capsule/Makefile
@@ -1,0 +1,9 @@
+docs: HELMDOCS_VERSION := v1.8.1
+docs: docker
+	@docker run --rm -v "$$(pwd):/helm-docs" -u $$(id -u) jnorwood/helm-docs:$(HELMDOCS_VERSION)
+
+docker:
+	@hash docker 2>/dev/null || {\
+		echo "You need docker" &&\
+		exit 1;\
+	}

--- a/charts/capsule/README.md.gotmpl
+++ b/charts/capsule/README.md.gotmpl
@@ -127,6 +127,34 @@ And optionally, depending on the values set:
 
 Capsule, as many other add-ons, defines its own set of Custom Resource Definitions (CRDs). Helm3 removed the old CRDs installation method for a more simple methodology. In the Helm Chart, there is now a special directory called `crds` to hold the CRDs. These CRDs are not templated, but will be installed by default when running a `helm install` for the chart. If the CRDs already exist (for example, you already executed `helm install`), it will be skipped with a warning. When you wish to skip the CRDs installation, and do not see the warning, you can pass the `--skip-crds` flag to the `helm install` command.
 
+## Cert-Manager integration
+
+You can enable the generation of certificates using `cert-manager` as follows.
+
+```
+helm upgrade --install capsule clastix/capsule --namespace capsule-system --create-namespace \
+  --set "certManager.generateCertificates=true" \
+  --set "tls.create=false" \
+  --set "tls.enableController=false"
+```
+
+With the usage of `tls.enableController=false` value, you're delegating the injection of the Validating and Mutating Webhooks' CA to `cert-manager`.
+Since Helm3 doesn't allow to template _CRDs_, you have to patch manually the Custom Resource Definition `tenants.capsule.clastix.io` adding the proper annotation (YMMV).
+
+```yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.5.0
+    cert-manager.io/inject-ca-from: capsule-system/capsule-webhook-cert
+  creationTimestamp: "2022-07-22T08:32:51Z"
+  generation: 45
+  name: tenants.capsule.clastix.io
+  resourceVersion: "9832"
+  uid: 61e287df-319b-476d-88d5-bdb8dc14d4a6
+```
+
 ## More
 
 See Capsule [tutorial](https://github.com/clastix/capsule/blob/master/docs/content/general/tutorial.md) for more information about how to use Capsule.

--- a/charts/capsule/templates/NOTES.txt
+++ b/charts/capsule/templates/NOTES.txt
@@ -5,7 +5,7 @@
 
 
    # Check the capsule logs
-   $ kubectl logs -f deployment/{{ template "capsule.fullname" . }}-controller-manager -c manager -n{{ .Release.Namespace }}
+   $ kubectl logs -f deployment/{{ template "capsule.fullname" . }}-controller-manager -c manager -n {{ .Release.Namespace }}
 
 - Manage this chart:
 

--- a/charts/capsule/templates/_helpers.tpl
+++ b/charts/capsule/templates/_helpers.tpl
@@ -123,5 +123,5 @@ Create the Capsule controller name to use
 Create the Capsule TLS Secret name to use
 */}}
 {{- define "capsule.secretTlsName" -}}
-{{- printf "%s-tls" (include "capsule.fullname" .) -}}
+{{ default ( printf "%s-tls" ( include "capsule.fullname" . ) ) .Values.tls.name }}
 {{- end }}

--- a/charts/capsule/templates/certs.yaml
+++ b/charts/capsule/templates/certs.yaml
@@ -1,3 +1,4 @@
+{{- if or (not .Values.certManager.generateCertificates) (.Values.tls.create) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -8,3 +9,4 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   name: {{ include "capsule.secretTlsName" . }}
+{{- end }}

--- a/charts/capsule/templates/configuration-default.yaml
+++ b/charts/capsule/templates/configuration-default.yaml
@@ -8,7 +8,7 @@ metadata:
     capsule.clastix.io/mutating-webhook-configuration-name: {{ include "capsule.fullname" . }}-mutating-webhook-configuration
     capsule.clastix.io/tls-secret-name: {{ include "capsule.secretTlsName" . }}
     capsule.clastix.io/validating-webhook-configuration-name: {{ include "capsule.fullname" . }}-validating-webhook-configuration
-    capsule.clastix.io/generate-certificates: "{{ .Values.manager.options.generateCertificates }}"
+    capsule.clastix.io/enable-tls-configuration: "{{ .Values.tls.enableController }}"
   {{- with .Values.customAnnotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/capsule/templates/mutatingwebhookconfiguration.yaml
+++ b/charts/capsule/templates/mutatingwebhookconfiguration.yaml
@@ -4,8 +4,11 @@ metadata:
   name: {{ include "capsule.fullname" . }}-mutating-webhook-configuration
   labels:
     {{- include "capsule.labels" . | nindent 4 }}
-  {{- with .Values.customAnnotations }}
   annotations:
+  {{- if .Values.certManager.generateCertificates }}
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "capsule.fullname" . }}-webhook-cert
+  {{-  end }}
+  {{- with .Values.customAnnotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
 webhooks:

--- a/charts/capsule/templates/post-install-job.yaml
+++ b/charts/capsule/templates/post-install-job.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.tls.create }}
 {{- $cmd := printf "while [ -z $$(kubectl -n $NAMESPACE get secret %s -o jsonpath='{.data.tls\\\\.crt}') ];" (include "capsule.secretTlsName" .) -}}
 {{- $cmd = printf "%s do echo 'waiting Capsule to be up and running...' && sleep 5;" $cmd -}}
 {{- $cmd = printf "%s done" $cmd -}}
@@ -45,3 +46,4 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
       serviceAccountName: {{ include "capsule.serviceAccountName" . }}
+{{- end }}

--- a/charts/capsule/templates/pre-delete-job.yaml
+++ b/charts/capsule/templates/pre-delete-job.yaml
@@ -1,5 +1,5 @@
 {{- $cmd := ""}}
-{{- if not .Values.certManager.generateCertificates }}
+{{- if or (.Values.tls.create) (.Values.certManager.generateCertificates) }}
 {{- $cmd = printf "%s kubectl delete secret -n $NAMESPACE %s --ignore-not-found &&" $cmd (include "capsule.secretTlsName" .) -}}
 {{- end }}
 {{- $cmd = printf "%s kubectl delete clusterroles.rbac.authorization.k8s.io capsule-namespace-deleter capsule-namespace-provisioner --ignore-not-found &&" $cmd -}}

--- a/charts/capsule/templates/validatingwebhookconfiguration.yaml
+++ b/charts/capsule/templates/validatingwebhookconfiguration.yaml
@@ -4,8 +4,11 @@ metadata:
   name: {{ include "capsule.fullname" . }}-validating-webhook-configuration
   labels:
     {{- include "capsule.labels" . | nindent 4 }}
-  {{- with .Values.customAnnotations }}
   annotations:
+  {{- if .Values.certManager.generateCertificates }}
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "capsule.fullname" . }}-webhook-cert
+  {{-  end }}
+  {{- with .Values.customAnnotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
 webhooks:

--- a/charts/capsule/values.yaml
+++ b/charts/capsule/values.yaml
@@ -2,6 +2,15 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+# Secret Options
+tls:
+  # -- Start the Capsule controller that injects the CA into mutating and validating webhooks, and CRD as well.
+  enableController: true
+  # -- When cert-manager is disabled, Capsule will generate the TLS certificate for webhook and CRDs conversion.
+  create: true
+  # -- Override name of the Capsule TLS Secret name when externally managed.
+  name: ""
+
 # Manager Options
 manager:
 

--- a/pkg/configuration/client.go
+++ b/pkg/configuration/client.go
@@ -78,8 +78,8 @@ func (c capsuleConfiguration) TLSSecretName() (name string) {
 	return
 }
 
-func (c capsuleConfiguration) GenerateCertificates() bool {
-	annotationValue, ok := c.retrievalFn().Annotations[capsulev1alpha1.GenerateCertificatesAnnotationName]
+func (c capsuleConfiguration) EnableTLSConfiguration() bool {
+	annotationValue, ok := c.retrievalFn().Annotations[capsulev1alpha1.EnableTLSConfigurationAnnotationName]
 
 	if ok {
 		value, err := strconv.ParseBool(annotationValue)

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -19,7 +19,9 @@ const (
 type Configuration interface {
 	ProtectedNamespaceRegexp() (*regexp.Regexp, error)
 	ForceTenantPrefix() bool
-	GenerateCertificates() bool
+	// EnableTLSConfiguration enabled the TLS reconciler, responsible for creating CA and TLS certificate required
+	// for the CRD conversion and webhooks.
+	EnableTLSConfiguration() bool
 	TLSSecretName() string
 	MutatingWebhookConfigurationName() string
 	ValidatingWebhookConfigurationName() string


### PR DESCRIPTION
This PR allows deeper integration with `cert-manager` by adding new Helm values.

- `certManager.generateCertificates`: allows to create the Certificate and Issuer requested by `cert-manager`, along with the required annotations for injecting the CA in the Mutating and Validating webhooks
- `tls.create`: allows to skip the creation of the secret, useful if it must be provided externally
- `tls.enableController`: allows to skip the start of the TLS reconciler, useful when `cert-manager` is injecting on its own the CA, or managed by a third party (e.g. Vault, or custom strategies)

Along with that, the `CapsuleConfiguration` has dropped the annotation `capsule.clastix.io/generate-certificates` in favor of `capsule.clastix.io/enable-tls-configuration` that allows controlling the start of the said reconciler. This cannot be considered a breaking change since the annotation hasn't been yet released in a stable version.