### PR TITLE
chore(maintainers): welcome oliver

### DIFF
--- a/.github/maintainers.yaml
+++ b/.github/maintainers.yaml
@@ -16,3 +16,8 @@
   projects:
     - https://github.com/clastix/capsule
     - https://github.com/clastix/capsule-proxy
+- name: Oliver Bähler
+  github: https://github.com/oliverbaehler
+  company: Bedag Informatik AG
+  projects:
+    - https://github.com/clastix/capsule


### PR DESCRIPTION
With the following PR, I'm proposing @oliverbaehler step in as maintainer to the current project.

In the last months, Oliver showed proactivity in triaging the issues of Capsule, proposing enhancements, and fixing issues. Furthermore, Oliver is maintaining a Capsule installation at his current company, offering the community experience with a real and production use-case.