### PR TITLE
Aligning documentation to v1beta2

### DIFF
--- a/api/v1beta2/ingress_options.go
+++ b/api/v1beta2/ingress_options.go
@@ -29,5 +29,5 @@ type IngressOptions struct {
 	// Specifies the allowed hostnames in Ingresses for the given Tenant. Capsule assures that all Ingress resources created in the Tenant can use only one of the allowed hostnames. Optional.
 	AllowedHostnames *api.AllowedListSpec `json:"allowedHostnames,omitempty"`
 	// Toggles the ability for Ingress resources created in a Tenant to have a hostname wildcard.
-	AllowWildcardHostnames bool `json:"allowWildcardHostnames"`
+	AllowWildcardHostnames bool `json:"allowWildcardHostnames,omitempty"`
 }

--- a/api/v1beta2/namespace_options.go
+++ b/api/v1beta2/namespace_options.go
@@ -14,7 +14,7 @@ type NamespaceOptions struct {
 	// Specifies additional labels and annotations the Capsule operator places on any Namespace resource in the Tenant. Optional.
 	AdditionalMetadata *api.AdditionalMetadataSpec `json:"additionalMetadata,omitempty"`
 	// Define the labels that a Tenant Owner cannot set for their Namespace resources.
-	ForbiddenLabels api.ForbiddenListSpec `json:"forbiddenLabels"`
+	ForbiddenLabels api.ForbiddenListSpec `json:"forbiddenLabels,omitempty"`
 	// Define the annotations that a Tenant Owner cannot set for their Namespace resources.
-	ForbiddenAnnotations api.ForbiddenListSpec `json:"forbiddenAnnotations"`
+	ForbiddenAnnotations api.ForbiddenListSpec `json:"forbiddenAnnotations,omitempty"`
 }

--- a/charts/capsule/crds/tenant-crd.yaml
+++ b/charts/capsule/crds/tenant-crd.yaml
@@ -1433,8 +1433,6 @@ spec:
                         - Namespace
                         - Disabled
                       type: string
-                  required:
-                    - allowWildcardHostnames
                   type: object
                 limitRanges:
                   description: Specifies the resource min/max usage restrictions to the Tenant. The assigned values are inherited by any namespace created in the Tenant. Optional.
@@ -1545,9 +1543,6 @@ spec:
                       format: int32
                       minimum: 1
                       type: integer
-                  required:
-                    - forbiddenAnnotations
-                    - forbiddenLabels
                   type: object
                 networkPolicies:
                   description: Specifies the NetworkPolicies assigned to the Tenant. The assigned NetworkPolicies are inherited by any namespace created in the Tenant. Optional.

--- a/config/crd/bases/capsule.clastix.io_tenants.yaml
+++ b/config/crd/bases/capsule.clastix.io_tenants.yaml
@@ -2131,8 +2131,6 @@ spec:
                     - Namespace
                     - Disabled
                     type: string
-                required:
-                - allowWildcardHostnames
                 type: object
               limitRanges:
                 description: Specifies the resource min/max usage restrictions to
@@ -2267,9 +2265,6 @@ spec:
                     format: int32
                     minimum: 1
                     type: integer
-                required:
-                - forbiddenAnnotations
-                - forbiddenLabels
                 type: object
               networkPolicies:
                 description: Specifies the NetworkPolicies assigned to the Tenant.

--- a/config/install.yaml
+++ b/config/install.yaml
@@ -1997,8 +1997,6 @@ spec:
                     - Namespace
                     - Disabled
                     type: string
-                required:
-                - allowWildcardHostnames
                 type: object
               limitRanges:
                 description: Specifies the resource min/max usage restrictions to the Tenant. The assigned values are inherited by any namespace created in the Tenant. Optional.
@@ -2109,9 +2107,6 @@ spec:
                     format: int32
                     minimum: 1
                     type: integer
-                required:
-                - forbiddenAnnotations
-                - forbiddenLabels
                 type: object
               networkPolicies:
                 description: Specifies the NetworkPolicies assigned to the Tenant. The assigned NetworkPolicies are inherited by any namespace created in the Tenant. Optional.

--- a/docs/content/contributing/development.md
+++ b/docs/content/contributing/development.md
@@ -152,7 +152,7 @@ $ kubectl -n capsule-system logs --all-containers -l control-plane=controller-ma
 
 # You may have a try to deploy a Tenant too to make sure it works end to end
 $ kubectl apply -f - <<EOF
-apiVersion: capsule.clastix.io/v1beta1
+apiVersion: capsule.clastix.io/v1beta2
 kind: Tenant
 metadata:
   name: oil
@@ -307,7 +307,7 @@ To verify that, we can open a new console and create a new Tenant:
 
 ```shell
 $ kubectl apply -f - <<EOF
-apiVersion: capsule.clastix.io/v1beta1
+apiVersion: capsule.clastix.io/v1beta2
 kind: Tenant
 metadata:
   name: gas

--- a/docs/content/general/crds-apis.md
+++ b/docs/content/general/crds-apis.md
@@ -3229,7 +3229,7 @@ Specifies options for the Ingress resources, such as allowed hostnames and Ingre
         <td>
           Toggles the ability for Ingress resources created in a Tenant to have a hostname wildcard.<br/>
         </td>
-        <td>true</td>
+        <td>false</td>
       </tr><tr>
         <td><b><a href="#tenantspecingressoptionsallowedclasses-1">allowedClasses</a></b></td>
         <td>object</td>
@@ -3518,24 +3518,24 @@ Specifies options for the Namespaces, such as additional metadata or maximum num
         </tr>
     </thead>
     <tbody><tr>
+        <td><b><a href="#tenantspecnamespaceoptionsadditionalmetadata-1">additionalMetadata</a></b></td>
+        <td>object</td>
+        <td>
+          Specifies additional labels and annotations the Capsule operator places on any Namespace resource in the Tenant. Optional.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b><a href="#tenantspecnamespaceoptionsforbiddenannotations">forbiddenAnnotations</a></b></td>
         <td>object</td>
         <td>
           Define the annotations that a Tenant Owner cannot set for their Namespace resources.<br/>
         </td>
-        <td>true</td>
+        <td>false</td>
       </tr><tr>
         <td><b><a href="#tenantspecnamespaceoptionsforbiddenlabels">forbiddenLabels</a></b></td>
         <td>object</td>
         <td>
           Define the labels that a Tenant Owner cannot set for their Namespace resources.<br/>
-        </td>
-        <td>true</td>
-      </tr><tr>
-        <td><b><a href="#tenantspecnamespaceoptionsadditionalmetadata-1">additionalMetadata</a></b></td>
-        <td>object</td>
-        <td>
-          Specifies additional labels and annotations the Capsule operator places on any Namespace resource in the Tenant. Optional.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -3546,6 +3546,39 @@ Specifies options for the Namespaces, such as additional metadata or maximum num
           <br/>
             <i>Format</i>: int32<br/>
             <i>Minimum</i>: 1<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### Tenant.spec.namespaceOptions.additionalMetadata
+
+
+
+Specifies additional labels and annotations the Capsule operator places on any Namespace resource in the Tenant. Optional.
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>annotations</b></td>
+        <td>map[string]string</td>
+        <td>
+          <br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>labels</b></td>
+        <td>map[string]string</td>
+        <td>
+          <br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -3610,39 +3643,6 @@ Define the labels that a Tenant Owner cannot set for their Namespace resources.
       </tr><tr>
         <td><b>deniedRegex</b></td>
         <td>string</td>
-        <td>
-          <br/>
-        </td>
-        <td>false</td>
-      </tr></tbody>
-</table>
-
-
-### Tenant.spec.namespaceOptions.additionalMetadata
-
-
-
-Specifies additional labels and annotations the Capsule operator places on any Namespace resource in the Tenant. Optional.
-
-<table>
-    <thead>
-        <tr>
-            <th>Name</th>
-            <th>Type</th>
-            <th>Description</th>
-            <th>Required</th>
-        </tr>
-    </thead>
-    <tbody><tr>
-        <td><b>annotations</b></td>
-        <td>map[string]string</td>
-        <td>
-          <br/>
-        </td>
-        <td>false</td>
-      </tr><tr>
-        <td><b>labels</b></td>
-        <td>map[string]string</td>
         <td>
           <br/>
         </td>

--- a/docs/content/general/getting-started.md
+++ b/docs/content/general/getting-started.md
@@ -35,7 +35,7 @@ Create the tenant as cluster admin:
 
 ```yaml
 kubectl create -f - << EOF
-apiVersion: capsule.clastix.io/v1beta1
+apiVersion: capsule.clastix.io/v1beta2
 kind: Tenant
 metadata:
   name: oil

--- a/docs/content/general/mtb.md
+++ b/docs/content/general/mtb.md
@@ -51,7 +51,7 @@ As cluster admin, create a tenant
 
 ```yaml
 kubectl create -f - <<EOF
-apiVersion: capsule.clastix.io/v1beta1
+apiVersion: capsule.clastix.io/v1beta2
 kind: Tenant
 metadata:
   name: oil
@@ -129,7 +129,7 @@ As cluster admin, create a tenant
 
 ```yaml
 kubectl create -f - <<EOF
-apiVersion: capsule.clastix.io/v1beta1
+apiVersion: capsule.clastix.io/v1beta2
 kind: Tenant
 metadata:
   name: oil
@@ -188,7 +188,7 @@ As cluster admin, create a tenant
 
 ```yaml
 kubectl create -f - <<EOF
-apiVersion: capsule.clastix.io/v1beta1
+apiVersion: capsule.clastix.io/v1beta2
 kind: Tenant
 metadata:
   name: oil
@@ -247,7 +247,7 @@ As cluster admin, create a tenant
 
 ```yaml
 kubectl create -f - <<EOF
-apiVersion: capsule.clastix.io/v1beta1
+apiVersion: capsule.clastix.io/v1beta2
 kind: Tenant
 metadata:
   name: oil
@@ -361,7 +361,7 @@ As cluster admin, create a tenant
 
 ```yaml
 kubectl create -f - <<EOF
-apiVersion: capsule.clastix.io/v1beta1
+apiVersion: capsule.clastix.io/v1beta2
 kind: Tenant
 metadata:
   name: oil
@@ -517,7 +517,7 @@ As cluster admin, create a couple of tenants
 
 ```yaml
 kubectl create -f - <<EOF
-apiVersion: capsule.clastix.io/v1beta1
+apiVersion: capsule.clastix.io/v1beta2
 kind: Tenant
 metadata:
   name: oil
@@ -535,7 +535,7 @@ and
 
 ```yaml
 kubectl create -f - <<EOF
-apiVersion: capsule.clastix.io/v1beta1
+apiVersion: capsule.clastix.io/v1beta2
 kind: Tenant
 metadata:
   name: gas
@@ -659,7 +659,7 @@ And assign it to the tenant
 
 ```yaml
 kubectl apply -f - << EOF
-apiVersion: capsule.clastix.io/v1beta1
+apiVersion: capsule.clastix.io/v1beta2
 kind: Tenant
 metadata:
   name: oil
@@ -737,7 +737,7 @@ As cluster admin, create a tenant
 
 ```yaml
 kubectl create -f - <<EOF
-apiVersion: capsule.clastix.io/v1beta1
+apiVersion: capsule.clastix.io/v1beta2
 kind: Tenant
 metadata:
   name: oil
@@ -807,7 +807,7 @@ As cluster admin, create a couple of tenants
 
 ```yaml
 kubectl create -f - <<EOF
-apiVersion: capsule.clastix.io/v1beta1
+apiVersion: capsule.clastix.io/v1beta2
 kind: Tenant
 metadata:
   name: oil
@@ -834,7 +834,7 @@ and
 
 ```yaml
 kubectl create -f - <<EOF
-apiVersion: capsule.clastix.io/v1beta1
+apiVersion: capsule.clastix.io/v1beta2
 kind: Tenant
 metadata:
   name: gas
@@ -956,7 +956,7 @@ And assign it to the tenant
 
 ```yaml
 kubectl apply -f - << EOF
-apiVersion: capsule.clastix.io/v1beta1
+apiVersion: capsule.clastix.io/v1beta2
 kind: Tenant
 metadata:
   name: oil
@@ -1072,7 +1072,7 @@ And assign it to the tenant
 
 ```yaml
 kubectl apply -f - << EOF
-apiVersion: capsule.clastix.io/v1beta1
+apiVersion: capsule.clastix.io/v1beta2
 kind: Tenant
 metadata:
   name: oil
@@ -1148,7 +1148,7 @@ As cluster admin, create a tenant
 
 ```yaml
 kubectl create -f - << EOF
-apiVersion: capsule.clastix.io/v1beta1
+apiVersion: capsule.clastix.io/v1beta2
 kind: Tenant
 metadata:
   name: oil
@@ -1231,7 +1231,7 @@ And assign it to the tenant
 
 ```yaml
 kubectl apply -f - << EOF
-apiVersion: capsule.clastix.io/v1beta1
+apiVersion: capsule.clastix.io/v1beta2
 kind: Tenant
 metadata:
   name: oil
@@ -1348,7 +1348,7 @@ And assign it to the tenant
 
 ```yaml
 kubectl apply -f - << EOF
-apiVersion: capsule.clastix.io/v1beta1
+apiVersion: capsule.clastix.io/v1beta2
 kind: Tenant
 metadata:
   name: oil
@@ -1489,7 +1489,7 @@ And assign it to the tenant
 
 ```yaml
 kubectl apply -f - << EOF
-apiVersion: capsule.clastix.io/v1beta1
+apiVersion: capsule.clastix.io/v1beta2
 kind: Tenant
 metadata:
   name: oil
@@ -1613,7 +1613,7 @@ And assign it to the tenant
 
 ```yaml
 kubectl apply -f - << EOF
-apiVersion: capsule.clastix.io/v1beta1
+apiVersion: capsule.clastix.io/v1beta2
 kind: Tenant
 metadata:
   name: oil
@@ -1687,12 +1687,14 @@ As cluster admin, create a tenant
 
 ```yaml
 kubectl create -f - << EOF
-apiVersion: capsule.clastix.io/v1beta1
+apiVersion: capsule.clastix.io/v1beta2
 kind: Tenant
 metadata:
   name: oil
 spec:
-  enableNodePorts: false
+  serviceOptions:
+    allowedServices:
+      nodePort: false
   owners:
   - kind: User
     name: alice
@@ -1763,7 +1765,7 @@ As cluster admin, create a tenant
 
 ```yaml
 kubectl create -f - <<EOF
-apiVersion: capsule.clastix.io/v1beta1
+apiVersion: capsule.clastix.io/v1beta2
 kind: Tenant
 metadata:
   name: oil
@@ -1830,7 +1832,7 @@ As cluster admin, create a tenant
 
 ```yaml
 kubectl create -f - <<EOF
-apiVersion: capsule.clastix.io/v1beta1
+apiVersion: capsule.clastix.io/v1beta2
 kind: Tenant
 metadata:
   name: oil
@@ -1896,7 +1898,7 @@ As cluster admin, create a tenant
 
 ```yaml
 kubectl create -f - << EOF
-apiVersion: capsule.clastix.io/v1beta1
+apiVersion: capsule.clastix.io/v1beta2
 kind: Tenant
 metadata:
   name: oil
@@ -2011,7 +2013,7 @@ And assign it to the tenant
 
 ```yaml
 kubectl apply -f - << EOF
-apiVersion: capsule.clastix.io/v1beta1
+apiVersion: capsule.clastix.io/v1beta2
 kind: Tenant
 metadata:
   name: oil
@@ -2106,7 +2108,7 @@ As cluster admin, create a tenant and assign the above Storage Class
 
 ```yaml
 kubectl create -f - << EOF
-apiVersion: capsule.clastix.io/v1beta1
+apiVersion: capsule.clastix.io/v1beta2
 kind: Tenant
 metadata:
   name: oil
@@ -2229,7 +2231,7 @@ And assign it to the tenant
 
 ```yaml
 kubectl apply -f - << EOF
-apiVersion: capsule.clastix.io/v1beta1
+apiVersion: capsule.clastix.io/v1beta2
 kind: Tenant
 metadata:
   name: oil

--- a/docs/content/general/proxy.md
+++ b/docs/content/general/proxy.md
@@ -104,7 +104,7 @@ For a web-based dashboard, like the [Kubernetes Dashboard](https://github.com/ku
 Each Tenant owner can have their capabilities managed pretty similar to a standard Kubernetes RBAC.
 
 ```yaml
-apiVersion: capsule.clastix.io/v1beta1
+apiVersion: capsule.clastix.io/v1beta2
 kind: Tenant
 metadata:
   name: my-tenant
@@ -171,7 +171,7 @@ namespace/solar-development created
 The Capsule Proxy gives the owners the ability to access the nodes matching the `.spec.nodeSelector` in the Tenant manifest:
 
 ```yaml
-apiVersion: capsule.clastix.io/v1beta1
+apiVersion: capsule.clastix.io/v1beta2
 kind: Tenant
 metadata:
   name: oil
@@ -209,7 +209,7 @@ These are mandatory in order to retrieve the list of the running Pods on the req
 A Tenant may be limited to use a set of allowed Storage Class resources, as follows.
 
 ```yaml
-apiVersion: capsule.clastix.io/v1beta1
+apiVersion: capsule.clastix.io/v1beta2
 kind: Tenant
 metadata:
   name: oil
@@ -267,7 +267,7 @@ provisioner: cephfs
 As for Storage Class, also Ingress Class can be enforced.
 
 ```yaml
-apiVersion: capsule.clastix.io/v1beta1
+apiVersion: capsule.clastix.io/v1beta2
 kind: Tenant
 metadata:
   name: oil
@@ -330,7 +330,7 @@ spec:
 Allowed PriorityClasses assigned to a Tenant Owner can be enforced as follows:
 
 ```yaml
-apiVersion: capsule.clastix.io/v1beta1
+apiVersion: capsule.clastix.io/v1beta2
 kind: Tenant
 metadata:
   name: oil
@@ -403,7 +403,7 @@ These tenant users, groups and services accounts have less privileged access tha
 
 As a Tenant Owner `alice`, you can create a `ProxySetting` resources to allow `bob` to list nodes, storage classes, ingress classes and priority classes
 ```yaml
-apiVersion: capsule.clastix.io/v1beta1
+apiVersion: capsule.clastix.io/v1beta2
 kind: ProxySetting
 metadata:
   name: sre-readers

--- a/docs/content/guides/flux2-capsule.md
+++ b/docs/content/guides/flux2-capsule.md
@@ -77,7 +77,7 @@ metadata:
   name: gitops-reconciler
   namespace: my-tenant
 ---
-apiVersion: capsule.clastix.io/v1beta1
+apiVersion: capsule.clastix.io/v1beta2
 kind: Tenant
 metadata:
   name: my-tenant
@@ -93,7 +93,7 @@ From now on, we'll refer to it as the **Tenant GitOps Reconciler**.
 We also need to state that Capsule should enforce tenant access control for requests coming from tenants, and we can do that by specifying one of the `Group`s bound by default by Kubernetes to the Tenant GitOps Reconciler `ServiceAccount` in the `CapsuleConfiguration`:
 
 ```yaml
-apiVersion: capsule.clastix.io/v1alpha1
+apiVersion: capsule.clastix.io/v1beta2
 kind: CapsuleConfiguration
 metadata:
   name: default
@@ -238,7 +238,7 @@ this is the required set of resources to setup a Tenant:
 - Additional binding to *cluster-admin* `ClusterRole` for the Tenant's `Namespace`s and `Namespace` of the Tenant GitOps Reconciler' `ServiceAccount`.
   By default Capsule binds only `admin` ClusterRole, which has no privileges over Custom Resources, but *cluster-admin* has. This is needed to operate on Flux CRs:
   ```yaml
-  apiVersion: capsule.clastix.io/v1beta1
+  apiVersion: capsule.clastix.io/v1beta2
   kind: Tenant
   metadata:
     name: my-tenant

--- a/docs/content/guides/pod-security.md
+++ b/docs/content/guides/pod-security.md
@@ -47,7 +47,7 @@ He can assign this role to all namespaces in a tenant by setting the tenant mani
 
 ```yaml
 kubectl apply -f - << EOF
-apiVersion: capsule.clastix.io/v1beta1
+apiVersion: capsule.clastix.io/v1beta2
 kind: Tenant
 metadata:
   name: oil
@@ -171,7 +171,7 @@ As cluster admin, create a tenant with additional labels:
 
 ```yaml
 kubectl apply -f - << EOF
-apiVersion: capsule.clastix.io/v1beta1
+apiVersion: capsule.clastix.io/v1beta2
 kind: Tenant
 metadata:
   name: oil
@@ -203,7 +203,7 @@ metadata:
     pod-security.kubernetes.io/audit: restricted
   name: oil-development
   ownerReferences:
-  - apiVersion: capsule.clastix.io/v1beta1
+  - apiVersion: capsule.clastix.io/v1beta2
     blockOwnerDeletion: true
     controller: true
     kind: Tenant

--- a/docs/content/guides/upgrading.md
+++ b/docs/content/guides/upgrading.md
@@ -1,17 +1,133 @@
-# Upgrading Tenant resource from v1alpha1 to v1beta1 version
+# Capsule upgrading guide
 
-With [Capsule v0.1.0](https://github.com/clastix/capsule/releases/tag/v0.1.0), the Tenant custom resource has been bumped to `v1beta1` from `v1alpha1` with additional fields addressing the new features implemented so far.
+List of Tenant API changes:
+
+- [Capsule v0.1.0](https://github.com/clastix/capsule/releases/tag/v0.1.0) bump to `v1beta1` from `v1alpha1`.
+- [Capsule v0.2.0](https://github.com/clastix/capsule/releases/tag/v0.1.0) bump to `v1beta2` from `v1beta1`, deprecating `v1alpha1`.
 
 This document aims to provide support and a guide on how to perform a clean upgrade to the latest API version in order to avoid service disruption and data loss.
 
-## Backup your cluster
+As an installation method, Helm is given for granted, YMMV using the `kustomize` manifest.
+
+## Considerations
 
 We strongly suggest performing a full backup of your Kubernetes cluster, such as storage and etcd.
-Use your favorite tool according to your needs.
+Use your favourite tool according to your needs.
+
+# Upgrading from v0.1.3 to v0.2.0
+
+## Scale down the Capsule controller
+
+Using the `kubectl` or Helm, scale down the Capsule controller manager: this is required to avoid the old Capsule version from processing objects that aren't yet installed as a CRD.
+
+```
+helm upgrade -n capsule-system capsule --set "replicaCount=0" 
+```
+
+> Ensure that all the Pods have been removed correctly.
+
+## Migrate manually the `CapsuleConfiguration` to the latest API version
+
+With the v0.2.0 release of Capsule and the new features introduced, the resource `CapsuleConfiguration` is offering a new API version, bumped to `v1beta1` from `v1alpha1`.
+
+Essentially, the `CapsuleConfiguration` is storing configuration flags that allow Capsule to be configured on the fly without requiring the operator to reload.
+This resource is read at the operator init-time when the conversion webhook offered by Capsule is not yet ready to serve any request.
+
+Migrating from v0.1.3 to v0.2.0 requires a manual conversion of your `CapsuleConfiguration` according to the latest version (currently, `v1beta2`).
+You can find further information about it at the section `CRDs APIs`.
+
+The deletion of the `CapsuleConfiguration` resource is required, along with the update of the related CRD.
+
+```
+kubectl delete capsuleconfiguration default
+kubectl apply -f https://raw.githubusercontent.com/clastix/capsule/v0.2.0/config/crd/bases/capsuleconfiguration-crd.yaml
+```
+
+During the Helm upgrade, a new `CapsuleConfiguration` will be created: please, refer to the Helm Chart values to pick up your desired settings.
+
+## Patch the Tenant custom resource definition
+
+Unfortunately, Helm doesn't manage the lifecycle of Custom Resource Definitions, additional details can be found [here](https://github.com/helm/community/blob/f9e06c16d89ccea1bea77c01a6a96ae3b309f823/architecture/crds.md).
+
+This process must be executed manually as follows:
+
+```
+kubectl apply -f https://raw.githubusercontent.com/clastix/capsule/v0.2.0/config/crd/bases/globaltenantresources-crd.yaml
+kubectl apply -f https://raw.githubusercontent.com/clastix/capsule/v0.2.0/config/crd/bases/tenant-crd.yaml
+kubectl apply -f https://raw.githubusercontent.com/clastix/capsule/v0.2.0/config/crd/bases/tenantresources-crd.yaml
+```
+
+> We're giving for granted that Capsule is installed in the `capsule-system` Namespace.
+> According to your needs you can change the Namespace at your wish, e.g.:
+>
+> ```bash
+> CUSTOM_NS="tenancy-operations"
+> 
+> for CR in capsuleconfigurations.capsule.clastix.io globaltenantresources.capsule.clastix.io tenantresources.capsule.clastix.io tenants.capsule.clastix.io; do
+>   kubectl patch crd capsuleconfigurations.capsule.clastix.io --type='json' -p=" [{'op': 'replace', 'path': '/spec/conversion/webhook/clientConfig/service/namespace', 'value': "${CUSTOM_NS}"}]"
+> done
+> ```
+
+## Update your Capsule Helm chart
+
+Ensure to update the Capsule repository to fetch the latest changes.
+
+```
+helm repo update
+```
+
+The latest Chart must be used, at the current time, 0.3.0 is expected for Capsule v0.2.0, you can fetch the full list of available charts with the following command.
+
+```
+helm search repo -l clastix/capsule
+```
+
+Since the Tenant custom resource definition has been patched with new fields, we can install back Capsule using the provided Helm chart.
+
+```
+helm upgrade --install capsule clastix/capsule -n capsule-system --create-namespace --version 0.3.0
+```
+
+This will start the Operator with the latest changes, and perform the required sync operations like:
+
+1. Ensuring the CA is still valid
+2. Ensuring a TLS certificate is valid for the local webhook server
+3. If not using the cert-manager integration, patching the Validating and Mutating Webhook Configuration resources with the Capsule CA
+4. If not using the cert-manager integration, patching the Capsule's Custom Resource Definitions conversion webhook fields with the Capsule CA
+
+## Ensure the conversion webhook is working
+
+Kubernetes Custom Resource definitions provide a conversion webhook that is used by an Operator to perform a seamless conversion between resources with different versioning.
+
+With the fresh new installation, Capsule patches all the required moving parts to ensure this conversion is put in place and uses the latest version (actually, `v1beta2`) for presenting the Tenant resources.
+
+You can check this behaviour by issuing the following command:
+
+```
+$: kubectl get tenants.v1beta2.capsule.clastix.io
+NAME   NAMESPACE QUOTA   NAMESPACE COUNT   OWNER NAME   OWNER KIND   NODE SELECTOR                  AGE
+oil    3                 0                 alice        User         {"kubernetes.io/os":"linux"}   3m43s
+```
+
+You should see all the previous Tenant resources converted in the new format and structure.
+
+```
+$: kubectl get tenants.v1beta2.capsule.clastix.io 
+NAME   STATE    NAMESPACE QUOTA   NAMESPACE COUNT   NODE SELECTOR                  AGE
+oil    Active   3                 0                 {"kubernetes.io/os":"linux"}   3m38s
+```
+
+> Resources are still persisted in etcd using the previous Tenant version (`v1beta1`) and the conversion is executed on-the-fly thanks to the conversion webhook.
+> If you'd like to decrease the pressure on Capsule due to the conversion webhook, we suggest performing a resource patching using the command `kubectl replace`:
+> in this way, the API Server will update the etcd key with the specification according to the new versioning, allowing to skip the conversion.
+>
+> The `kubectl replace` command must be triggered when the Capsule webhook is up and running to allow the conversion between versions.
+
+# Upgrading from < v0.1.0 up to v0.1.3
 
 ## Uninstall the old Capsule release
 
-If you're using Helm as package manager, all the Operator resources such as Deployment, Service, Role Binding, and etc. must be deleted.
+If you're using Helm as package manager, all the Operator resources such as Deployment, Service, Role Binding, etc. must be deleted.
 
 ```
 helm uninstall -n capsule-system capsule 
@@ -21,7 +137,7 @@ Ensure that everything has been removed correctly, especially the Secret resourc
 
 ## Patch the Tenant custom resource definition
 
-Helm doesn't manage the lifecycle of Custom Resource Definitions, additional details can be found [here](https://github.com/helm/community/blob/f9e06c16d89ccea1bea77c01a6a96ae3b309f823/architecture/crds.md).
+Unfortunately, Helm doesn't manage the lifecycle of Custom Resource Definitions, additional details can be found [here](https://github.com/helm/community/blob/f9e06c16d89ccea1bea77c01a6a96ae3b309f823/architecture/crds.md).
 
 This process must be executed manually as follows:
 
@@ -36,23 +152,27 @@ kubectl apply -f https://raw.githubusercontent.com/clastix/capsule/v0.1.0/config
 Since the Tenant custom resource definition has been patched with new fields, we can install back Capsule using the provided Helm chart.
 
 ```
-helm upgrade --install capsule clastix/capsule -n capsule-system --create-namespace
+helm upgrade --install capsule clastix/capsule -n capsule-system --create-namespace --version=DESIRED_VERSION
 ```
 
-This will start the Operator that will perform several required actions, such as:
+> Please, note the `DESIRED_VERSION`: you have to pick the Helm chart version according to the Capsule version you'd like to upgrade to.
+>
+> You can retrieve it by browsing the GitHub source code picking the Capsule tag as ref and inspecting the file `Chart.yaml` available in the folder `charts/capsule`.
 
-1. Generating a new CA 
-2. Generating new TLS certificates for the local webhook server 
-3. Patching the Validating and Mutating Webhook Configuration resources with the fresh new CA 
+This will start the operator that will perform several required actions, such as:
+
+1. Generating a new CA
+2. Generating new TLS certificates for the local webhook server
+3. Patching the Validating and Mutating Webhook Configuration resources with the fresh new CA
 4. Patching the Custom Resource Definition tenant conversion webhook CA
 
 ## Ensure the conversion webhook is working
 
-Kubernetes Custom Resource definitions provide a conversion webhook that is used by an Operator to perform seamless conversion between resources with different versioning.
+Kubernetes Custom Resource definitions provide a conversion webhook that is used by an Operator to perform a seamless conversion between resources with different versioning.
 
-With the fresh new installation, Capsule patched all the required moving parts to ensure this conversion is put in place, and using the latest version (actually, `v1beta1`) for presenting the Tenant resources.
+With the fresh new installation, Capsule patched all the required moving parts to ensure this conversion is put in place and using the latest version (actually, `v1beta1`) for presenting the Tenant resources.
 
-You can check this behavior by issuing the following command:
+You can check this behaviour by issuing the following command:
 
 ```
 $: kubectl get tenants.v1beta1.capsule.clastix.io
@@ -60,7 +180,7 @@ NAME   NAMESPACE QUOTA   NAMESPACE COUNT   OWNER NAME   OWNER KIND   NODE SELECT
 oil    3                 0                 alice        User         {"kubernetes.io/os":"linux"}   3m43s
 ```
 
-You should see all the previous Tenant resources converted in the new format and structure.
+You should see all the previous Tenant resources converted into the new format and structure.
 
 ```
 $: kubectl get tenants.v1beta1.capsule.clastix.io 
@@ -68,6 +188,5 @@ NAME   STATE    NAMESPACE QUOTA   NAMESPACE COUNT   NODE SELECTOR               
 oil    Active   3                 0                 {"kubernetes.io/os":"linux"}   3m38s
 ```
 
-> Resources are still persisted in etcd using the `v1alpha1` specification and the conversion is executed on-the-fly thanks to the conversion webhook.
-> If you'd like to decrease the pressure on Capsule due to the conversion webhook, we suggest performing a resource patching using the command `kubectl replace`:
-> in this way, the API Server will update the etcd key with the specification according to the new versioning, allowing to skip the conversion.
+> Resources are still persisted in etcd using the v1alpha1 specification and the conversion is executed on-the-fly thanks to the conversion webhook.
+> If you'd like to decrease the pressure on Capsule due to the conversion webhook, we suggest performing a resource patching using the command kubectl replace: in this way, the API Server will update the etcd key with the specification according to the new versioning, allowing to skip the conversion.

--- a/docs/gridsome.server.js
+++ b/docs/gridsome.server.js
@@ -71,7 +71,7 @@ module.exports = function (api) {
               path: '/docs/guides/velero'
             },
             {
-              label: 'Upgrading Tenant version',
+              label: 'Upgrading Capsule',
               path: '/docs/guides/upgrading'
             },
             {


### PR DESCRIPTION
Closes #652.

Some API changes were requested due to missing `,omitempty` values that were preventing a smooth usage of Capsule.

All the Tenant manifests have been tested one by one, this leads me to the `,omitempty` issue.