### PR TITLE
refactor(helm): add control for securityContext

### DIFF
--- a/charts/capsule/Chart.yaml
+++ b/charts/capsule/Chart.yaml
@@ -21,7 +21,7 @@ sources:
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.3.2
+version: 0.3.3
 
 # This is the version number of the application being deployed.
 # This version number should be incremented each time you make changes to the application.

--- a/charts/capsule/README.md
+++ b/charts/capsule/README.md
@@ -72,9 +72,11 @@ Here the values you can override:
 | mutatingWebhooksTimeoutSeconds | int | `30` | Timeout in seconds for mutating webhooks |
 | nodeSelector | object | `{}` | Set the node selector for the Capsule pod |
 | podAnnotations | object | `{}` | Annotations to add to the capsule pod. |
+| podSecurityContext | object | `{"runAsGroup":1002,"runAsNonRoot":true,"runAsUser":1002}` | Set the securityContext for the Capsule pod |
 | podSecurityPolicy.enabled | bool | `false` | Specify if a Pod Security Policy must be created |
 | priorityClassName | string | `""` | Set the priority class name of the Capsule pod |
 | replicaCount | int | `1` | Set the replica count for capsule pod |
+| securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true}` | Set the securityContext for the Capsule container |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account. |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created. |
 | serviceAccount.name | string | `"capsule"` | The name of the service account to use. If not set and `serviceAccount.create=true`, a name is generated using the fullname template |

--- a/charts/capsule/README.md
+++ b/charts/capsule/README.md
@@ -72,7 +72,7 @@ Here the values you can override:
 | mutatingWebhooksTimeoutSeconds | int | `30` | Timeout in seconds for mutating webhooks |
 | nodeSelector | object | `{}` | Set the node selector for the Capsule pod |
 | podAnnotations | object | `{}` | Annotations to add to the capsule pod. |
-| podSecurityContext | object | `{"runAsGroup":1002,"runAsNonRoot":true,"runAsUser":1002}` | Set the securityContext for the Capsule pod |
+| podSecurityContext | object | `{"runAsGroup":1002,"runAsNonRoot":true,"runAsUser":1002,"seccompProfile":{"type":"RuntimeDefault"}}` | Set the securityContext for the Capsule pod |
 | podSecurityPolicy.enabled | bool | `false` | Specify if a Pod Security Policy must be created |
 | priorityClassName | string | `""` | Set the priority class name of the Capsule pod |
 | replicaCount | int | `1` | Set the replica count for capsule pod |

--- a/charts/capsule/templates/daemonset.yaml
+++ b/charts/capsule/templates/daemonset.yaml
@@ -29,6 +29,10 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "capsule.serviceAccountName" . }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if .Values.manager.hostNetwork }}
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
@@ -84,5 +88,5 @@ spec:
           resources:
             {{- toYaml .Values.manager.resources | nindent 12 }}
           securityContext:
-            allowPrivilegeEscalation: false
+            {{- toYaml .Values.securityContext | nindent 12 }}
 {{- end }}

--- a/charts/capsule/templates/deployment.yaml
+++ b/charts/capsule/templates/deployment.yaml
@@ -28,6 +28,10 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "capsule.serviceAccountName" . }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if .Values.manager.hostNetwork }}
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
@@ -83,5 +87,5 @@ spec:
           resources:
             {{- toYaml .Values.manager.resources | nindent 12 }}
           securityContext:
-            allowPrivilegeEscalation: false
+            {{- toYaml .Values.securityContext | nindent 12 }}
 {{- end }}

--- a/charts/capsule/values.yaml
+++ b/charts/capsule/values.yaml
@@ -79,6 +79,8 @@ priorityClassName: '' # system-cluster-critical
 
 # -- Set the securityContext for the Capsule pod
 podSecurityContext:
+  seccompProfile:
+    type: "RuntimeDefault"
   runAsGroup: 1002
   runAsNonRoot: true
   runAsUser: 1002

--- a/charts/capsule/values.yaml
+++ b/charts/capsule/values.yaml
@@ -77,6 +77,21 @@ podAnnotations: {}
 # -- Set the priority class name of the Capsule pod
 priorityClassName: '' # system-cluster-critical
 
+# -- Set the securityContext for the Capsule pod
+podSecurityContext:
+  runAsGroup: 1002
+  runAsNonRoot: true
+  runAsUser: 1002
+
+
+# -- Set the securityContext for the Capsule container
+securityContext:
+  capabilities:
+    drop:
+    - ALL
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+
 # -- Set the node selector for the Capsule pod
 nodeSelector: {}
 #  node-role.kubernetes.io/master: ""


### PR DESCRIPTION
Signed-off-by: Zemtsov Vladimir <zemtsov.v@mail366.com>


Small feature for control securityContext in helm

Local test:
```bash
~ kind create cluster
...


~ k cluster-info
Kubernetes control plane is running at https://127.0.0.1:60977
CoreDNS is running at https://127.0.0.1:60977/api/v1/namespaces/kube-system/services/kube-dns:dns/proxy

To further debug and diagnose cluster problems, use 'kubectl cluster-info dump'.


~ helm install capsule . -n capsule-system --create-namespace
NAME: capsule
LAST DEPLOYED: Fri Feb 10 09:57:02 2023
NAMESPACE: capsule-system
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
  ...

~ k get deployments.apps -n capsule-system capsule-controller-manager -o yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  ...
  name: capsule-controller-manager
  namespace: capsule-system
  ...
spec:
  ...
  template:
    ...
    spec:
      containers:
      - ...
        ...
        securityContext:
          allowPrivilegeEscalation: false
          capabilities:
            drop:
            - ALL
          readOnlyRootFilesystem: true
        ...
      ...
      securityContext:
        runAsGroup: 1002
        runAsNonRoot: true
        runAsUser: 1002
      ...



~ k create -f - << EOF
apiVersion: capsule.clastix.io/v1beta2
kind: Tenant
metadata:
  name: oil
spec:
  owners:
  - name: alice
    kind: User
EOF
tenant.capsule.clastix.io/oil created


~ k get tenants
NAME   STATE    NAMESPACE QUOTA   NAMESPACE COUNT   NODE SELECTOR   AGE
oil    Active                     0                                 4s


~ ../../hack/create-user.sh alice oil
creating certs in TMPDIR /var/folders/c7/78_t4pvj5zd2qrcwgq05h7_40000gn/T/tmp.Sr8bOiQ3
merging groups /O=capsule.clastix.io
Generating RSA private key, 2048 bit long modulus
......................................+++
........+++
e is 65537 (0x10001)
certificatesigningrequest.certificates.k8s.io/alice-oil created
certificatesigningrequest.certificates.k8s.io/alice-oil approved
kubeconfig file is: alice-oil.kubeconfig
to use it as alice export KUBECONFIG=alice-oil.kubeconfig


~ export KUBECONFIG=alice-oil.kubeconfig
~ k create namespace oil-production
namespace/oil-production created

~ k create namespace oil-development
namespace/oil-development created


~ export KUBECONFIG=
~ k get tenant oil
NAME   STATE    NAMESPACE QUOTA   NAMESPACE COUNT   NODE SELECTOR   AGE
oil    Active                     2                                 38s
```