### PR TITLE
feat: add runtimeclass kind

### DIFF
--- a/api/v1beta2/owner.go
+++ b/api/v1beta2/owner.go
@@ -34,7 +34,7 @@ func (p ProxyOperation) String() string {
 	return string(p)
 }
 
-// +kubebuilder:validation:Enum=Nodes;StorageClasses;IngressClasses;PriorityClasses
+// +kubebuilder:validation:Enum=Nodes;StorageClasses;IngressClasses;PriorityClasses;RuntimeClasses;PersistentVolumes
 type ProxyServiceKind string
 
 func (p ProxyServiceKind) String() string {
@@ -42,10 +42,12 @@ func (p ProxyServiceKind) String() string {
 }
 
 const (
-	NodesProxy           ProxyServiceKind = "Nodes"
-	StorageClassesProxy  ProxyServiceKind = "StorageClasses"
-	IngressClassesProxy  ProxyServiceKind = "IngressClasses"
-	PriorityClassesProxy ProxyServiceKind = "PriorityClasses"
+	NodesProxy             ProxyServiceKind = "Nodes"
+	StorageClassesProxy    ProxyServiceKind = "StorageClasses"
+	IngressClassesProxy    ProxyServiceKind = "IngressClasses"
+	PriorityClassesProxy   ProxyServiceKind = "PriorityClasses"
+	RuntimeClassesProxy    ProxyServiceKind = "RuntimeClasses"
+	PersistentVolumesProxy ProxyServiceKind = "PersistentVolumes"
 
 	ListOperation   ProxyOperation = "List"
 	UpdateOperation ProxyOperation = "Update"

--- a/charts/capsule/crds/tenant-crd.yaml
+++ b/charts/capsule/crds/tenant-crd.yaml
@@ -54,17 +54,22 @@ spec:
           name: Age
           type: date
       deprecated: true
-      deprecationWarning: This version is going to be dropped in the upcoming version of Capsule; please, migrate to v1beta2 version.
+      deprecationWarning: This version is going to be dropped in the upcoming version
+        of Capsule; please, migrate to v1beta2 version.
       name: v1alpha1
       schema:
         openAPIV3Schema:
           description: Tenant is the Schema for the tenants API.
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
               type: string
             metadata:
               type: object
@@ -79,19 +84,31 @@ spec:
                       subjects:
                         description: kubebuilder:validation:Minimum=1
                         items:
-                          description: Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.
+                          description: Subject contains a reference to the object or
+                            user identities a role binding applies to.  This can either
+                            hold a direct API object reference, or a value for non-objects
+                            such as user and group names.
                           properties:
                             apiGroup:
-                              description: APIGroup holds the API group of the referenced subject. Defaults to "" for ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
+                              description: APIGroup holds the API group of the referenced
+                                subject. Defaults to "" for ServiceAccount subjects.
+                                Defaults to "rbac.authorization.k8s.io" for User and
+                                Group subjects.
                               type: string
                             kind:
-                              description: Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount". If the Authorizer does not recognized the kind value, the Authorizer should report an error.
+                              description: Kind of object being referenced. Values defined
+                                by this API group are "User", "Group", and "ServiceAccount".
+                                If the Authorizer does not recognized the kind value,
+                                the Authorizer should report an error.
                               type: string
                             name:
                               description: Name of the object being referenced.
                               type: string
                             namespace:
-                              description: Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty the Authorizer should report an error.
+                              description: Namespace of the referenced object.  If the
+                                object kind is non-namespace, such as "User" or "Group",
+                                and this value is not empty the Authorizer should report
+                                an error.
                               type: string
                           required:
                             - kind
@@ -143,12 +160,15 @@ spec:
                   type: object
                 limitRanges:
                   items:
-                    description: LimitRangeSpec defines a min/max usage limit for resources that match on kind.
+                    description: LimitRangeSpec defines a min/max usage limit for resources
+                      that match on kind.
                     properties:
                       limits:
-                        description: Limits is the list of LimitRangeItem objects that are enforced.
+                        description: Limits is the list of LimitRangeItem objects that
+                          are enforced.
                         items:
-                          description: LimitRangeItem defines a min/max usage limit for any resource that matches on kind.
+                          description: LimitRangeItem defines a min/max usage limit
+                            for any resource that matches on kind.
                           properties:
                             default:
                               additionalProperties:
@@ -157,7 +177,8 @@ spec:
                                   - type: string
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
-                              description: Default resource requirement limit value by resource name if resource limit is omitted.
+                              description: Default resource requirement limit value
+                                by resource name if resource limit is omitted.
                               type: object
                             defaultRequest:
                               additionalProperties:
@@ -166,7 +187,9 @@ spec:
                                   - type: string
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
-                              description: DefaultRequest is the default resource requirement request value by resource name if resource request is omitted.
+                              description: DefaultRequest is the default resource requirement
+                                request value by resource name if resource request is
+                                omitted.
                               type: object
                             max:
                               additionalProperties:
@@ -175,7 +198,8 @@ spec:
                                   - type: string
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
-                              description: Max usage constraints on this kind by resource name.
+                              description: Max usage constraints on this kind by resource
+                                name.
                               type: object
                             maxLimitRequestRatio:
                               additionalProperties:
@@ -184,7 +208,11 @@ spec:
                                   - type: string
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
-                              description: MaxLimitRequestRatio if specified, the named resource must have a request and limit that are both non-zero where limit divided by request is less than or equal to the enumerated value; this represents the max burst for the named resource.
+                              description: MaxLimitRequestRatio if specified, the named
+                                resource must have a request and limit that are both
+                                non-zero where limit divided by request is less than
+                                or equal to the enumerated value; this represents the
+                                max burst for the named resource.
                               type: object
                             min:
                               additionalProperties:
@@ -193,10 +221,12 @@ spec:
                                   - type: string
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
-                              description: Min usage constraints on this kind by resource name.
+                              description: Min usage constraints on this kind by resource
+                                name.
                               type: object
                             type:
-                              description: Type of resource that this limit applies to.
+                              description: Type of resource that this limit applies
+                                to.
                               type: string
                           required:
                             - type
@@ -226,44 +256,93 @@ spec:
                     description: NetworkPolicySpec provides the specification of a NetworkPolicy
                     properties:
                       egress:
-                        description: List of egress rules to be applied to the selected pods. Outgoing traffic is allowed if there are no NetworkPolicies selecting the pod (and cluster policy otherwise allows the traffic), OR if the traffic matches at least one egress rule across all of the NetworkPolicy objects whose podSelector matches the pod. If this field is empty then this NetworkPolicy limits all outgoing traffic (and serves solely to ensure that the pods it selects are isolated by default). This field is beta-level in 1.8
+                        description: List of egress rules to be applied to the selected
+                          pods. Outgoing traffic is allowed if there are no NetworkPolicies
+                          selecting the pod (and cluster policy otherwise allows the
+                          traffic), OR if the traffic matches at least one egress rule
+                          across all of the NetworkPolicy objects whose podSelector
+                          matches the pod. If this field is empty then this NetworkPolicy
+                          limits all outgoing traffic (and serves solely to ensure that
+                          the pods it selects are isolated by default). This field is
+                          beta-level in 1.8
                         items:
-                          description: NetworkPolicyEgressRule describes a particular set of traffic that is allowed out of pods matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and to. This type is beta-level in 1.8
+                          description: NetworkPolicyEgressRule describes a particular
+                            set of traffic that is allowed out of pods matched by a
+                            NetworkPolicySpec's podSelector. The traffic must match
+                            both ports and to. This type is beta-level in 1.8
                           properties:
                             ports:
-                              description: List of destination ports for outgoing traffic. Each item in this list is combined using a logical OR. If this field is empty or missing, this rule matches all ports (traffic not restricted by port). If this field is present and contains at least one item, then this rule allows traffic only if the traffic matches at least one port in the list.
+                              description: List of destination ports for outgoing traffic.
+                                Each item in this list is combined using a logical OR.
+                                If this field is empty or missing, this rule matches
+                                all ports (traffic not restricted by port). If this
+                                field is present and contains at least one item, then
+                                this rule allows traffic only if the traffic matches
+                                at least one port in the list.
                               items:
-                                description: NetworkPolicyPort describes a port to allow traffic on
+                                description: NetworkPolicyPort describes a port to allow
+                                  traffic on
                                 properties:
                                   endPort:
-                                    description: If set, indicates that the range of ports from port to endPort, inclusive, should be allowed by the policy. This field cannot be defined if the port field is not defined or if the port field is defined as a named (string) port. The endPort must be equal or greater than port. This feature is in Beta state and is enabled by default. It can be disabled using the Feature Gate "NetworkPolicyEndPort".
+                                    description: If set, indicates that the range of
+                                      ports from port to endPort, inclusive, should
+                                      be allowed by the policy. This field cannot be
+                                      defined if the port field is not defined or if
+                                      the port field is defined as a named (string)
+                                      port. The endPort must be equal or greater than
+                                      port. This feature is in Beta state and is enabled
+                                      by default. It can be disabled using the Feature
+                                      Gate "NetworkPolicyEndPort".
                                     format: int32
                                     type: integer
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: The port on the given protocol. This can either be a numerical or named port on a pod. If this field is not provided, this matches all port names and numbers. If present, only traffic on the specified protocol AND port will be matched.
+                                    description: The port on the given protocol. This
+                                      can either be a numerical or named port on a pod.
+                                      If this field is not provided, this matches all
+                                      port names and numbers. If present, only traffic
+                                      on the specified protocol AND port will be matched.
                                     x-kubernetes-int-or-string: true
                                   protocol:
                                     default: TCP
-                                    description: The protocol (TCP, UDP, or SCTP) which traffic must match. If not specified, this field defaults to TCP.
+                                    description: The protocol (TCP, UDP, or SCTP) which
+                                      traffic must match. If not specified, this field
+                                      defaults to TCP.
                                     type: string
                                 type: object
                               type: array
                             to:
-                              description: List of destinations for outgoing traffic of pods selected for this rule. Items in this list are combined using a logical OR operation. If this field is empty or missing, this rule matches all destinations (traffic not restricted by destination). If this field is present and contains at least one item, this rule allows traffic only if the traffic matches at least one item in the to list.
+                              description: List of destinations for outgoing traffic
+                                of pods selected for this rule. Items in this list are
+                                combined using a logical OR operation. If this field
+                                is empty or missing, this rule matches all destinations
+                                (traffic not restricted by destination). If this field
+                                is present and contains at least one item, this rule
+                                allows traffic only if the traffic matches at least
+                                one item in the to list.
                               items:
-                                description: NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of fields are allowed
+                                description: NetworkPolicyPeer describes a peer to allow
+                                  traffic to/from. Only certain combinations of fields
+                                  are allowed
                                 properties:
                                   ipBlock:
-                                    description: IPBlock defines policy on a particular IPBlock. If this field is set then neither of the other fields can be.
+                                    description: IPBlock defines policy on a particular
+                                      IPBlock. If this field is set then neither of
+                                      the other fields can be.
                                     properties:
                                       cidr:
-                                        description: CIDR is a string representing the IP Block Valid examples are "192.168.1.1/24" or "2001:db9::/64"
+                                        description: CIDR is a string representing the
+                                          IP Block Valid examples are "192.168.1.1/24"
+                                          or "2001:db9::/64"
                                         type: string
                                       except:
-                                        description: Except is a slice of CIDRs that should not be included within an IP Block Valid examples are "192.168.1.1/24" or "2001:db9::/64" Except values will be rejected if they are outside the CIDR range
+                                        description: Except is a slice of CIDRs that
+                                          should not be included within an IP Block
+                                          Valid examples are "192.168.1.1/24" or "2001:db9::/64"
+                                          Except values will be rejected if they are
+                                          outside the CIDR range
                                         items:
                                           type: string
                                         type: array
@@ -271,21 +350,43 @@ spec:
                                       - cidr
                                     type: object
                                   namespaceSelector:
-                                    description: "Selects Namespaces using cluster-scoped labels. This field follows standard label selector semantics; if present but empty, it selects all namespaces. \n If PodSelector is also set, then the NetworkPolicyPeer as a whole selects the Pods matching PodSelector in the Namespaces selected by NamespaceSelector. Otherwise it selects all Pods in the Namespaces selected by NamespaceSelector."
+                                    description: "Selects Namespaces using cluster-scoped
+                                    labels. This field follows standard label selector
+                                    semantics; if present but empty, it selects all
+                                    namespaces. \n If PodSelector is also set, then
+                                    the NetworkPolicyPeer as a whole selects the Pods
+                                    matching PodSelector in the Namespaces selected
+                                    by NamespaceSelector. Otherwise it selects all
+                                    Pods in the Namespaces selected by NamespaceSelector."
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        description: matchExpressions is a list of label
+                                          selector requirements. The requirements are
+                                          ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement
+                                            is a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -297,26 +398,54 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only "value".
+                                          The requirements are ANDed.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   podSelector:
-                                    description: "This is a label selector which selects Pods. This field follows standard label selector semantics; if present but empty, it selects all pods. \n If NamespaceSelector is also set, then the NetworkPolicyPeer as a whole selects the Pods matching PodSelector in the Namespaces selected by NamespaceSelector. Otherwise it selects the Pods matching PodSelector in the policy's own Namespace."
+                                    description: "This is a label selector which selects
+                                    Pods. This field follows standard label selector
+                                    semantics; if present but empty, it selects all
+                                    pods. \n If NamespaceSelector is also set, then
+                                    the NetworkPolicyPeer as a whole selects the Pods
+                                    matching PodSelector in the Namespaces selected
+                                    by NamespaceSelector. Otherwise it selects the
+                                    Pods matching PodSelector in the policy's own
+                                    Namespace."
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        description: matchExpressions is a list of label
+                                          selector requirements. The requirements are
+                                          ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement
+                                            is a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -328,7 +457,12 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only "value".
+                                          The requirements are ANDed.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
@@ -337,23 +471,51 @@ spec:
                           type: object
                         type: array
                       ingress:
-                        description: List of ingress rules to be applied to the selected pods. Traffic is allowed to a pod if there are no NetworkPolicies selecting the pod (and cluster policy otherwise allows the traffic), OR if the traffic source is the pod's local node, OR if the traffic matches at least one ingress rule across all of the NetworkPolicy objects whose podSelector matches the pod. If this field is empty then this NetworkPolicy does not allow any traffic (and serves solely to ensure that the pods it selects are isolated by default)
+                        description: List of ingress rules to be applied to the selected
+                          pods. Traffic is allowed to a pod if there are no NetworkPolicies
+                          selecting the pod (and cluster policy otherwise allows the
+                          traffic), OR if the traffic source is the pod's local node,
+                          OR if the traffic matches at least one ingress rule across
+                          all of the NetworkPolicy objects whose podSelector matches
+                          the pod. If this field is empty then this NetworkPolicy does
+                          not allow any traffic (and serves solely to ensure that the
+                          pods it selects are isolated by default)
                         items:
-                          description: NetworkPolicyIngressRule describes a particular set of traffic that is allowed to the pods matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and from.
+                          description: NetworkPolicyIngressRule describes a particular
+                            set of traffic that is allowed to the pods matched by a
+                            NetworkPolicySpec's podSelector. The traffic must match
+                            both ports and from.
                           properties:
                             from:
-                              description: List of sources which should be able to access the pods selected for this rule. Items in this list are combined using a logical OR operation. If this field is empty or missing, this rule matches all sources (traffic not restricted by source). If this field is present and contains at least one item, this rule allows traffic only if the traffic matches at least one item in the from list.
+                              description: List of sources which should be able to access
+                                the pods selected for this rule. Items in this list
+                                are combined using a logical OR operation. If this field
+                                is empty or missing, this rule matches all sources (traffic
+                                not restricted by source). If this field is present
+                                and contains at least one item, this rule allows traffic
+                                only if the traffic matches at least one item in the
+                                from list.
                               items:
-                                description: NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of fields are allowed
+                                description: NetworkPolicyPeer describes a peer to allow
+                                  traffic to/from. Only certain combinations of fields
+                                  are allowed
                                 properties:
                                   ipBlock:
-                                    description: IPBlock defines policy on a particular IPBlock. If this field is set then neither of the other fields can be.
+                                    description: IPBlock defines policy on a particular
+                                      IPBlock. If this field is set then neither of
+                                      the other fields can be.
                                     properties:
                                       cidr:
-                                        description: CIDR is a string representing the IP Block Valid examples are "192.168.1.1/24" or "2001:db9::/64"
+                                        description: CIDR is a string representing the
+                                          IP Block Valid examples are "192.168.1.1/24"
+                                          or "2001:db9::/64"
                                         type: string
                                       except:
-                                        description: Except is a slice of CIDRs that should not be included within an IP Block Valid examples are "192.168.1.1/24" or "2001:db9::/64" Except values will be rejected if they are outside the CIDR range
+                                        description: Except is a slice of CIDRs that
+                                          should not be included within an IP Block
+                                          Valid examples are "192.168.1.1/24" or "2001:db9::/64"
+                                          Except values will be rejected if they are
+                                          outside the CIDR range
                                         items:
                                           type: string
                                         type: array
@@ -361,21 +523,43 @@ spec:
                                       - cidr
                                     type: object
                                   namespaceSelector:
-                                    description: "Selects Namespaces using cluster-scoped labels. This field follows standard label selector semantics; if present but empty, it selects all namespaces. \n If PodSelector is also set, then the NetworkPolicyPeer as a whole selects the Pods matching PodSelector in the Namespaces selected by NamespaceSelector. Otherwise it selects all Pods in the Namespaces selected by NamespaceSelector."
+                                    description: "Selects Namespaces using cluster-scoped
+                                    labels. This field follows standard label selector
+                                    semantics; if present but empty, it selects all
+                                    namespaces. \n If PodSelector is also set, then
+                                    the NetworkPolicyPeer as a whole selects the Pods
+                                    matching PodSelector in the Namespaces selected
+                                    by NamespaceSelector. Otherwise it selects all
+                                    Pods in the Namespaces selected by NamespaceSelector."
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        description: matchExpressions is a list of label
+                                          selector requirements. The requirements are
+                                          ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement
+                                            is a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -387,26 +571,54 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only "value".
+                                          The requirements are ANDed.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   podSelector:
-                                    description: "This is a label selector which selects Pods. This field follows standard label selector semantics; if present but empty, it selects all pods. \n If NamespaceSelector is also set, then the NetworkPolicyPeer as a whole selects the Pods matching PodSelector in the Namespaces selected by NamespaceSelector. Otherwise it selects the Pods matching PodSelector in the policy's own Namespace."
+                                    description: "This is a label selector which selects
+                                    Pods. This field follows standard label selector
+                                    semantics; if present but empty, it selects all
+                                    pods. \n If NamespaceSelector is also set, then
+                                    the NetworkPolicyPeer as a whole selects the Pods
+                                    matching PodSelector in the Namespaces selected
+                                    by NamespaceSelector. Otherwise it selects the
+                                    Pods matching PodSelector in the policy's own
+                                    Namespace."
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        description: matchExpressions is a list of label
+                                          selector requirements. The requirements are
+                                          ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement
+                                            is a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -418,51 +630,94 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only "value".
+                                          The requirements are ANDed.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                 type: object
                               type: array
                             ports:
-                              description: List of ports which should be made accessible on the pods selected for this rule. Each item in this list is combined using a logical OR. If this field is empty or missing, this rule matches all ports (traffic not restricted by port). If this field is present and contains at least one item, then this rule allows traffic only if the traffic matches at least one port in the list.
+                              description: List of ports which should be made accessible
+                                on the pods selected for this rule. Each item in this
+                                list is combined using a logical OR. If this field is
+                                empty or missing, this rule matches all ports (traffic
+                                not restricted by port). If this field is present and
+                                contains at least one item, then this rule allows traffic
+                                only if the traffic matches at least one port in the
+                                list.
                               items:
-                                description: NetworkPolicyPort describes a port to allow traffic on
+                                description: NetworkPolicyPort describes a port to allow
+                                  traffic on
                                 properties:
                                   endPort:
-                                    description: If set, indicates that the range of ports from port to endPort, inclusive, should be allowed by the policy. This field cannot be defined if the port field is not defined or if the port field is defined as a named (string) port. The endPort must be equal or greater than port. This feature is in Beta state and is enabled by default. It can be disabled using the Feature Gate "NetworkPolicyEndPort".
+                                    description: If set, indicates that the range of
+                                      ports from port to endPort, inclusive, should
+                                      be allowed by the policy. This field cannot be
+                                      defined if the port field is not defined or if
+                                      the port field is defined as a named (string)
+                                      port. The endPort must be equal or greater than
+                                      port. This feature is in Beta state and is enabled
+                                      by default. It can be disabled using the Feature
+                                      Gate "NetworkPolicyEndPort".
                                     format: int32
                                     type: integer
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: The port on the given protocol. This can either be a numerical or named port on a pod. If this field is not provided, this matches all port names and numbers. If present, only traffic on the specified protocol AND port will be matched.
+                                    description: The port on the given protocol. This
+                                      can either be a numerical or named port on a pod.
+                                      If this field is not provided, this matches all
+                                      port names and numbers. If present, only traffic
+                                      on the specified protocol AND port will be matched.
                                     x-kubernetes-int-or-string: true
                                   protocol:
                                     default: TCP
-                                    description: The protocol (TCP, UDP, or SCTP) which traffic must match. If not specified, this field defaults to TCP.
+                                    description: The protocol (TCP, UDP, or SCTP) which
+                                      traffic must match. If not specified, this field
+                                      defaults to TCP.
                                     type: string
                                 type: object
                               type: array
                           type: object
                         type: array
                       podSelector:
-                        description: Selects the pods to which this NetworkPolicy object applies. The array of ingress rules is applied to any pods selected by this field. Multiple network policies can select the same set of pods. In this case, the ingress rules for each are combined additively. This field is NOT optional and follows standard label selector semantics. An empty podSelector matches all pods in this namespace.
+                        description: Selects the pods to which this NetworkPolicy object
+                          applies. The array of ingress rules is applied to any pods
+                          selected by this field. Multiple network policies can select
+                          the same set of pods. In this case, the ingress rules for
+                          each are combined additively. This field is NOT optional and
+                          follows standard label selector semantics. An empty podSelector
+                          matches all pods in this namespace.
                         properties:
                           matchExpressions:
-                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
                             items:
-                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                              description: A label selector requirement is a selector
+                                that contains values, a key, and an operator that relates
+                                the key and values.
                               properties:
                                 key:
-                                  description: key is the label key that the selector applies to.
+                                  description: key is the label key that the selector
+                                    applies to.
                                   type: string
                                 operator:
-                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  description: operator represents a key's relationship
+                                    to a set of values. Valid operators are In, NotIn,
+                                    Exists and DoesNotExist.
                                   type: string
                                 values:
-                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                  description: values is an array of string values.
+                                    If the operator is In or NotIn, the values array
+                                    must be non-empty. If the operator is Exists or
+                                    DoesNotExist, the values array must be empty. This
+                                    array is replaced during a strategic merge patch.
                                   items:
                                     type: string
                                   type: array
@@ -474,14 +729,31 @@ spec:
                           matchLabels:
                             additionalProperties:
                               type: string
-                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            description: matchLabels is a map of {key,value} pairs.
+                              A single {key,value} in the matchLabels map is equivalent
+                              to an element of matchExpressions, whose key field is
+                              "key", the operator is "In", and the values array contains
+                              only "value". The requirements are ANDed.
                             type: object
                         type: object
                         x-kubernetes-map-type: atomic
                       policyTypes:
-                        description: List of rule types that the NetworkPolicy relates to. Valid options are ["Ingress"], ["Egress"], or ["Ingress", "Egress"]. If this field is not specified, it will default based on the existence of Ingress or Egress rules; policies that contain an Egress section are assumed to affect Egress, and all policies (whether or not they contain an Ingress section) are assumed to affect Ingress. If you want to write an egress-only policy, you must explicitly specify policyTypes [ "Egress" ]. Likewise, if you want to write a policy that specifies that no egress is allowed, you must specify a policyTypes value that include "Egress" (since such a policy would not include an Egress section and would otherwise default to just [ "Ingress" ]). This field is beta-level in 1.8
+                        description: List of rule types that the NetworkPolicy relates
+                          to. Valid options are ["Ingress"], ["Egress"], or ["Ingress",
+                          "Egress"]. If this field is not specified, it will default
+                          based on the existence of Ingress or Egress rules; policies
+                          that contain an Egress section are assumed to affect Egress,
+                          and all policies (whether or not they contain an Ingress section)
+                          are assumed to affect Ingress. If you want to write an egress-only
+                          policy, you must explicitly specify policyTypes [ "Egress"
+                          ]. Likewise, if you want to write a policy that specifies
+                          that no egress is allowed, you must specify a policyTypes
+                          value that include "Egress" (since such a policy would not
+                          include an Egress section and would otherwise default to just
+                          [ "Ingress" ]). This field is beta-level in 1.8
                         items:
-                          description: PolicyType string describes the NetworkPolicy type This type is beta-level in 1.8
+                          description: PolicyType string describes the NetworkPolicy
+                            type This type is beta-level in 1.8
                           type: string
                         type: array
                     required:
@@ -508,7 +780,8 @@ spec:
                   type: object
                 resourceQuotas:
                   items:
-                    description: ResourceQuotaSpec defines the desired hard limits to enforce for Quota.
+                    description: ResourceQuotaSpec defines the desired hard limits to
+                      enforce for Quota.
                     properties:
                       hard:
                         additionalProperties:
@@ -517,24 +790,39 @@ spec:
                             - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: 'hard is the set of desired hard limits for each named resource. More info: https://kubernetes.io/docs/concepts/policy/resource-quotas/'
+                        description: 'hard is the set of desired hard limits for each
+                        named resource. More info: https://kubernetes.io/docs/concepts/policy/resource-quotas/'
                         type: object
                       scopeSelector:
-                        description: scopeSelector is also a collection of filters like scopes that must match each object tracked by a quota but expressed using ScopeSelectorOperator in combination with possible values. For a resource to match, both scopes AND scopeSelector (if specified in spec), must be matched.
+                        description: scopeSelector is also a collection of filters like
+                          scopes that must match each object tracked by a quota but
+                          expressed using ScopeSelectorOperator in combination with
+                          possible values. For a resource to match, both scopes AND
+                          scopeSelector (if specified in spec), must be matched.
                         properties:
                           matchExpressions:
-                            description: A list of scope selector requirements by scope of the resources.
+                            description: A list of scope selector requirements by scope
+                              of the resources.
                             items:
-                              description: A scoped-resource selector requirement is a selector that contains values, a scope name, and an operator that relates the scope name and values.
+                              description: A scoped-resource selector requirement is
+                                a selector that contains values, a scope name, and an
+                                operator that relates the scope name and values.
                               properties:
                                 operator:
-                                  description: Represents a scope's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist.
+                                  description: Represents a scope's relationship to
+                                    a set of values. Valid operators are In, NotIn,
+                                    Exists, DoesNotExist.
                                   type: string
                                 scopeName:
-                                  description: The name of the scope that the selector applies to.
+                                  description: The name of the scope that the selector
+                                    applies to.
                                   type: string
                                 values:
-                                  description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                  description: An array of string values. If the operator
+                                    is In or NotIn, the values array must be non-empty.
+                                    If the operator is Exists or DoesNotExist, the values
+                                    array must be empty. This array is replaced during
+                                    a strategic merge patch.
                                   items:
                                     type: string
                                   type: array
@@ -546,9 +834,12 @@ spec:
                         type: object
                         x-kubernetes-map-type: atomic
                       scopes:
-                        description: A collection of filters that must match each object tracked by a quota. If not specified, the quota matches all objects.
+                        description: A collection of filters that must match each object
+                          tracked by a quota. If not specified, the quota matches all
+                          objects.
                         items:
-                          description: A ResourceQuotaScope defines a filter that must match each object tracked by a quota
+                          description: A ResourceQuotaScope defines a filter that must
+                            match each object tracked by a quota
                           type: string
                         type: array
                     type: object
@@ -620,10 +911,14 @@ spec:
           description: Tenant is the Schema for the tenants API.
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
               type: string
             metadata:
               type: object
@@ -631,7 +926,9 @@ spec:
               description: TenantSpec defines the desired state of Tenant.
               properties:
                 additionalRoleBindings:
-                  description: Specifies additional RoleBindings assigned to the Tenant. Capsule will ensure that all namespaces in the Tenant always contain the RoleBinding for the given ClusterRole. Optional.
+                  description: Specifies additional RoleBindings assigned to the Tenant.
+                    Capsule will ensure that all namespaces in the Tenant always contain
+                    the RoleBinding for the given ClusterRole. Optional.
                   items:
                     properties:
                       clusterRoleName:
@@ -639,19 +936,31 @@ spec:
                       subjects:
                         description: kubebuilder:validation:Minimum=1
                         items:
-                          description: Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.
+                          description: Subject contains a reference to the object or
+                            user identities a role binding applies to.  This can either
+                            hold a direct API object reference, or a value for non-objects
+                            such as user and group names.
                           properties:
                             apiGroup:
-                              description: APIGroup holds the API group of the referenced subject. Defaults to "" for ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
+                              description: APIGroup holds the API group of the referenced
+                                subject. Defaults to "" for ServiceAccount subjects.
+                                Defaults to "rbac.authorization.k8s.io" for User and
+                                Group subjects.
                               type: string
                             kind:
-                              description: Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount". If the Authorizer does not recognized the kind value, the Authorizer should report an error.
+                              description: Kind of object being referenced. Values defined
+                                by this API group are "User", "Group", and "ServiceAccount".
+                                If the Authorizer does not recognized the kind value,
+                                the Authorizer should report an error.
                               type: string
                             name:
                               description: Name of the object being referenced.
                               type: string
                             namespace:
-                              description: Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty the Authorizer should report an error.
+                              description: Namespace of the referenced object.  If the
+                                object kind is non-namespace, such as "User" or "Group",
+                                and this value is not empty the Authorizer should report
+                                an error.
                               type: string
                           required:
                             - kind
@@ -665,7 +974,9 @@ spec:
                     type: object
                   type: array
                 containerRegistries:
-                  description: Specifies the trusted Image Registries assigned to the Tenant. Capsule assures that all Pods resources created in the Tenant can use only one of the allowed trusted registries. Optional.
+                  description: Specifies the trusted Image Registries assigned to the
+                    Tenant. Capsule assures that all Pods resources created in the Tenant
+                    can use only one of the allowed trusted registries. Optional.
                   properties:
                     allowed:
                       items:
@@ -675,7 +986,9 @@ spec:
                       type: string
                   type: object
                 imagePullPolicies:
-                  description: Specify the allowed values for the imagePullPolicies option in Pod resources. Capsule assures that all Pod resources created in the Tenant can use only one of the allowed policy. Optional.
+                  description: Specify the allowed values for the imagePullPolicies
+                    option in Pod resources. Capsule assures that all Pod resources
+                    created in the Tenant can use only one of the allowed policy. Optional.
                   items:
                     enum:
                       - Always
@@ -684,10 +997,14 @@ spec:
                     type: string
                   type: array
                 ingressOptions:
-                  description: Specifies options for the Ingress resources, such as allowed hostnames and IngressClass. Optional.
+                  description: Specifies options for the Ingress resources, such as
+                    allowed hostnames and IngressClass. Optional.
                   properties:
                     allowedClasses:
-                      description: Specifies the allowed IngressClasses assigned to the Tenant. Capsule assures that all Ingress resources created in the Tenant can use only one of the allowed IngressClasses. Optional.
+                      description: Specifies the allowed IngressClasses assigned to
+                        the Tenant. Capsule assures that all Ingress resources created
+                        in the Tenant can use only one of the allowed IngressClasses.
+                        Optional.
                       properties:
                         allowed:
                           items:
@@ -697,7 +1014,10 @@ spec:
                           type: string
                       type: object
                     allowedHostnames:
-                      description: Specifies the allowed hostnames in Ingresses for the given Tenant. Capsule assures that all Ingress resources created in the Tenant can use only one of the allowed hostnames. Optional.
+                      description: Specifies the allowed hostnames in Ingresses for
+                        the given Tenant. Capsule assures that all Ingress resources
+                        created in the Tenant can use only one of the allowed hostnames.
+                        Optional.
                       properties:
                         allowed:
                           items:
@@ -708,7 +1028,15 @@ spec:
                       type: object
                     hostnameCollisionScope:
                       default: Disabled
-                      description: "Defines the scope of hostname collision check performed when Tenant Owners create Ingress with allowed hostnames. \n - Cluster: disallow the creation of an Ingress if the pair hostname and path is already used across the Namespaces managed by Capsule. \n - Tenant: disallow the creation of an Ingress if the pair hostname and path is already used across the Namespaces of the Tenant. \n - Namespace: disallow the creation of an Ingress if the pair hostname and path is already used in the Ingress Namespace. \n Optional."
+                      description: "Defines the scope of hostname collision check performed
+                      when Tenant Owners create Ingress with allowed hostnames. \n
+                      - Cluster: disallow the creation of an Ingress if the pair hostname
+                      and path is already used across the Namespaces managed by Capsule.
+                      \n - Tenant: disallow the creation of an Ingress if the pair
+                      hostname and path is already used across the Namespaces of the
+                      Tenant. \n - Namespace: disallow the creation of an Ingress
+                      if the pair hostname and path is already used in the Ingress
+                      Namespace. \n Optional."
                       enum:
                         - Cluster
                         - Tenant
@@ -717,16 +1045,21 @@ spec:
                       type: string
                   type: object
                 limitRanges:
-                  description: Specifies the resource min/max usage restrictions to the Tenant. The assigned values are inherited by any namespace created in the Tenant. Optional.
+                  description: Specifies the resource min/max usage restrictions to
+                    the Tenant. The assigned values are inherited by any namespace created
+                    in the Tenant. Optional.
                   properties:
                     items:
                       items:
-                        description: LimitRangeSpec defines a min/max usage limit for resources that match on kind.
+                        description: LimitRangeSpec defines a min/max usage limit for
+                          resources that match on kind.
                         properties:
                           limits:
-                            description: Limits is the list of LimitRangeItem objects that are enforced.
+                            description: Limits is the list of LimitRangeItem objects
+                              that are enforced.
                             items:
-                              description: LimitRangeItem defines a min/max usage limit for any resource that matches on kind.
+                              description: LimitRangeItem defines a min/max usage limit
+                                for any resource that matches on kind.
                               properties:
                                 default:
                                   additionalProperties:
@@ -735,7 +1068,8 @@ spec:
                                       - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
-                                  description: Default resource requirement limit value by resource name if resource limit is omitted.
+                                  description: Default resource requirement limit value
+                                    by resource name if resource limit is omitted.
                                   type: object
                                 defaultRequest:
                                   additionalProperties:
@@ -744,7 +1078,9 @@ spec:
                                       - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
-                                  description: DefaultRequest is the default resource requirement request value by resource name if resource request is omitted.
+                                  description: DefaultRequest is the default resource
+                                    requirement request value by resource name if resource
+                                    request is omitted.
                                   type: object
                                 max:
                                   additionalProperties:
@@ -753,7 +1089,8 @@ spec:
                                       - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
-                                  description: Max usage constraints on this kind by resource name.
+                                  description: Max usage constraints on this kind by
+                                    resource name.
                                   type: object
                                 maxLimitRequestRatio:
                                   additionalProperties:
@@ -762,7 +1099,11 @@ spec:
                                       - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
-                                  description: MaxLimitRequestRatio if specified, the named resource must have a request and limit that are both non-zero where limit divided by request is less than or equal to the enumerated value; this represents the max burst for the named resource.
+                                  description: MaxLimitRequestRatio if specified, the
+                                    named resource must have a request and limit that
+                                    are both non-zero where limit divided by request
+                                    is less than or equal to the enumerated value; this
+                                    represents the max burst for the named resource.
                                   type: object
                                 min:
                                   additionalProperties:
@@ -771,10 +1112,12 @@ spec:
                                       - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
-                                  description: Min usage constraints on this kind by resource name.
+                                  description: Min usage constraints on this kind by
+                                    resource name.
                                   type: object
                                 type:
-                                  description: Type of resource that this limit applies to.
+                                  description: Type of resource that this limit applies
+                                    to.
                                   type: string
                               required:
                                 - type
@@ -786,10 +1129,14 @@ spec:
                       type: array
                   type: object
                 namespaceOptions:
-                  description: Specifies options for the Namespaces, such as additional metadata or maximum number of namespaces allowed for that Tenant. Once the namespace quota assigned to the Tenant has been reached, the Tenant owner cannot create further namespaces. Optional.
+                  description: Specifies options for the Namespaces, such as additional
+                    metadata or maximum number of namespaces allowed for that Tenant.
+                    Once the namespace quota assigned to the Tenant has been reached,
+                    the Tenant owner cannot create further namespaces. Optional.
                   properties:
                     additionalMetadata:
-                      description: Specifies additional labels and annotations the Capsule operator places on any Namespace resource in the Tenant. Optional.
+                      description: Specifies additional labels and annotations the Capsule
+                        operator places on any Namespace resource in the Tenant. Optional.
                       properties:
                         annotations:
                           additionalProperties:
@@ -801,57 +1148,116 @@ spec:
                           type: object
                       type: object
                     quota:
-                      description: Specifies the maximum number of namespaces allowed for that Tenant. Once the namespace quota assigned to the Tenant has been reached, the Tenant owner cannot create further namespaces. Optional.
+                      description: Specifies the maximum number of namespaces allowed
+                        for that Tenant. Once the namespace quota assigned to the Tenant
+                        has been reached, the Tenant owner cannot create further namespaces.
+                        Optional.
                       format: int32
                       minimum: 1
                       type: integer
                   type: object
                 networkPolicies:
-                  description: Specifies the NetworkPolicies assigned to the Tenant. The assigned NetworkPolicies are inherited by any namespace created in the Tenant. Optional.
+                  description: Specifies the NetworkPolicies assigned to the Tenant.
+                    The assigned NetworkPolicies are inherited by any namespace created
+                    in the Tenant. Optional.
                   properties:
                     items:
                       items:
-                        description: NetworkPolicySpec provides the specification of a NetworkPolicy
+                        description: NetworkPolicySpec provides the specification of
+                          a NetworkPolicy
                         properties:
                           egress:
-                            description: List of egress rules to be applied to the selected pods. Outgoing traffic is allowed if there are no NetworkPolicies selecting the pod (and cluster policy otherwise allows the traffic), OR if the traffic matches at least one egress rule across all of the NetworkPolicy objects whose podSelector matches the pod. If this field is empty then this NetworkPolicy limits all outgoing traffic (and serves solely to ensure that the pods it selects are isolated by default). This field is beta-level in 1.8
+                            description: List of egress rules to be applied to the selected
+                              pods. Outgoing traffic is allowed if there are no NetworkPolicies
+                              selecting the pod (and cluster policy otherwise allows
+                              the traffic), OR if the traffic matches at least one egress
+                              rule across all of the NetworkPolicy objects whose podSelector
+                              matches the pod. If this field is empty then this NetworkPolicy
+                              limits all outgoing traffic (and serves solely to ensure
+                              that the pods it selects are isolated by default). This
+                              field is beta-level in 1.8
                             items:
-                              description: NetworkPolicyEgressRule describes a particular set of traffic that is allowed out of pods matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and to. This type is beta-level in 1.8
+                              description: NetworkPolicyEgressRule describes a particular
+                                set of traffic that is allowed out of pods matched by
+                                a NetworkPolicySpec's podSelector. The traffic must
+                                match both ports and to. This type is beta-level in
+                                1.8
                               properties:
                                 ports:
-                                  description: List of destination ports for outgoing traffic. Each item in this list is combined using a logical OR. If this field is empty or missing, this rule matches all ports (traffic not restricted by port). If this field is present and contains at least one item, then this rule allows traffic only if the traffic matches at least one port in the list.
+                                  description: List of destination ports for outgoing
+                                    traffic. Each item in this list is combined using
+                                    a logical OR. If this field is empty or missing,
+                                    this rule matches all ports (traffic not restricted
+                                    by port). If this field is present and contains
+                                    at least one item, then this rule allows traffic
+                                    only if the traffic matches at least one port in
+                                    the list.
                                   items:
-                                    description: NetworkPolicyPort describes a port to allow traffic on
+                                    description: NetworkPolicyPort describes a port
+                                      to allow traffic on
                                     properties:
                                       endPort:
-                                        description: If set, indicates that the range of ports from port to endPort, inclusive, should be allowed by the policy. This field cannot be defined if the port field is not defined or if the port field is defined as a named (string) port. The endPort must be equal or greater than port. This feature is in Beta state and is enabled by default. It can be disabled using the Feature Gate "NetworkPolicyEndPort".
+                                        description: If set, indicates that the range
+                                          of ports from port to endPort, inclusive,
+                                          should be allowed by the policy. This field
+                                          cannot be defined if the port field is not
+                                          defined or if the port field is defined as
+                                          a named (string) port. The endPort must be
+                                          equal or greater than port. This feature is
+                                          in Beta state and is enabled by default. It
+                                          can be disabled using the Feature Gate "NetworkPolicyEndPort".
                                         format: int32
                                         type: integer
                                       port:
                                         anyOf:
                                           - type: integer
                                           - type: string
-                                        description: The port on the given protocol. This can either be a numerical or named port on a pod. If this field is not provided, this matches all port names and numbers. If present, only traffic on the specified protocol AND port will be matched.
+                                        description: The port on the given protocol.
+                                          This can either be a numerical or named port
+                                          on a pod. If this field is not provided, this
+                                          matches all port names and numbers. If present,
+                                          only traffic on the specified protocol AND
+                                          port will be matched.
                                         x-kubernetes-int-or-string: true
                                       protocol:
                                         default: TCP
-                                        description: The protocol (TCP, UDP, or SCTP) which traffic must match. If not specified, this field defaults to TCP.
+                                        description: The protocol (TCP, UDP, or SCTP)
+                                          which traffic must match. If not specified,
+                                          this field defaults to TCP.
                                         type: string
                                     type: object
                                   type: array
                                 to:
-                                  description: List of destinations for outgoing traffic of pods selected for this rule. Items in this list are combined using a logical OR operation. If this field is empty or missing, this rule matches all destinations (traffic not restricted by destination). If this field is present and contains at least one item, this rule allows traffic only if the traffic matches at least one item in the to list.
+                                  description: List of destinations for outgoing traffic
+                                    of pods selected for this rule. Items in this list
+                                    are combined using a logical OR operation. If this
+                                    field is empty or missing, this rule matches all
+                                    destinations (traffic not restricted by destination).
+                                    If this field is present and contains at least one
+                                    item, this rule allows traffic only if the traffic
+                                    matches at least one item in the to list.
                                   items:
-                                    description: NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of fields are allowed
+                                    description: NetworkPolicyPeer describes a peer
+                                      to allow traffic to/from. Only certain combinations
+                                      of fields are allowed
                                     properties:
                                       ipBlock:
-                                        description: IPBlock defines policy on a particular IPBlock. If this field is set then neither of the other fields can be.
+                                        description: IPBlock defines policy on a particular
+                                          IPBlock. If this field is set then neither
+                                          of the other fields can be.
                                         properties:
                                           cidr:
-                                            description: CIDR is a string representing the IP Block Valid examples are "192.168.1.1/24" or "2001:db9::/64"
+                                            description: CIDR is a string representing
+                                              the IP Block Valid examples are "192.168.1.1/24"
+                                              or "2001:db9::/64"
                                             type: string
                                           except:
-                                            description: Except is a slice of CIDRs that should not be included within an IP Block Valid examples are "192.168.1.1/24" or "2001:db9::/64" Except values will be rejected if they are outside the CIDR range
+                                            description: Except is a slice of CIDRs
+                                              that should not be included within an
+                                              IP Block Valid examples are "192.168.1.1/24"
+                                              or "2001:db9::/64" Except values will
+                                              be rejected if they are outside the CIDR
+                                              range
                                             items:
                                               type: string
                                             type: array
@@ -859,21 +1265,45 @@ spec:
                                           - cidr
                                         type: object
                                       namespaceSelector:
-                                        description: "Selects Namespaces using cluster-scoped labels. This field follows standard label selector semantics; if present but empty, it selects all namespaces. \n If PodSelector is also set, then the NetworkPolicyPeer as a whole selects the Pods matching PodSelector in the Namespaces selected by NamespaceSelector. Otherwise it selects all Pods in the Namespaces selected by NamespaceSelector."
+                                        description: "Selects Namespaces using cluster-scoped
+                                        labels. This field follows standard label
+                                        selector semantics; if present but empty,
+                                        it selects all namespaces. \n If PodSelector
+                                        is also set, then the NetworkPolicyPeer as
+                                        a whole selects the Pods matching PodSelector
+                                        in the Namespaces selected by NamespaceSelector.
+                                        Otherwise it selects all Pods in the Namespaces
+                                        selected by NamespaceSelector."
                                         properties:
                                           matchExpressions:
-                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The requirements
+                                              are ANDed.
                                             items:
-                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
                                               properties:
                                                 key:
-                                                  description: key is the label key that the selector applies to.
+                                                  description: key is the label key
+                                                    that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  description: operator represents a
+                                                    key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists
+                                                    and DoesNotExist.
                                                   type: string
                                                 values:
-                                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                  description: values is an array of
+                                                    string values. If the operator is
+                                                    In or NotIn, the values array must
+                                                    be non-empty. If the operator is
+                                                    Exists or DoesNotExist, the values
+                                                    array must be empty. This array
+                                                    is replaced during a strategic merge
+                                                    patch.
                                                   items:
                                                     type: string
                                                   type: array
@@ -885,26 +1315,55 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       podSelector:
-                                        description: "This is a label selector which selects Pods. This field follows standard label selector semantics; if present but empty, it selects all pods. \n If NamespaceSelector is also set, then the NetworkPolicyPeer as a whole selects the Pods matching PodSelector in the Namespaces selected by NamespaceSelector. Otherwise it selects the Pods matching PodSelector in the policy's own Namespace."
+                                        description: "This is a label selector which
+                                        selects Pods. This field follows standard
+                                        label selector semantics; if present but empty,
+                                        it selects all pods. \n If NamespaceSelector
+                                        is also set, then the NetworkPolicyPeer as
+                                        a whole selects the Pods matching PodSelector
+                                        in the Namespaces selected by NamespaceSelector.
+                                        Otherwise it selects the Pods matching PodSelector
+                                        in the policy's own Namespace."
                                         properties:
                                           matchExpressions:
-                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The requirements
+                                              are ANDed.
                                             items:
-                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
                                               properties:
                                                 key:
-                                                  description: key is the label key that the selector applies to.
+                                                  description: key is the label key
+                                                    that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  description: operator represents a
+                                                    key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists
+                                                    and DoesNotExist.
                                                   type: string
                                                 values:
-                                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                  description: values is an array of
+                                                    string values. If the operator is
+                                                    In or NotIn, the values array must
+                                                    be non-empty. If the operator is
+                                                    Exists or DoesNotExist, the values
+                                                    array must be empty. This array
+                                                    is replaced during a strategic merge
+                                                    patch.
                                                   items:
                                                     type: string
                                                   type: array
@@ -916,7 +1375,12 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
@@ -925,23 +1389,53 @@ spec:
                               type: object
                             type: array
                           ingress:
-                            description: List of ingress rules to be applied to the selected pods. Traffic is allowed to a pod if there are no NetworkPolicies selecting the pod (and cluster policy otherwise allows the traffic), OR if the traffic source is the pod's local node, OR if the traffic matches at least one ingress rule across all of the NetworkPolicy objects whose podSelector matches the pod. If this field is empty then this NetworkPolicy does not allow any traffic (and serves solely to ensure that the pods it selects are isolated by default)
+                            description: List of ingress rules to be applied to the
+                              selected pods. Traffic is allowed to a pod if there are
+                              no NetworkPolicies selecting the pod (and cluster policy
+                              otherwise allows the traffic), OR if the traffic source
+                              is the pod's local node, OR if the traffic matches at
+                              least one ingress rule across all of the NetworkPolicy
+                              objects whose podSelector matches the pod. If this field
+                              is empty then this NetworkPolicy does not allow any traffic
+                              (and serves solely to ensure that the pods it selects
+                              are isolated by default)
                             items:
-                              description: NetworkPolicyIngressRule describes a particular set of traffic that is allowed to the pods matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and from.
+                              description: NetworkPolicyIngressRule describes a particular
+                                set of traffic that is allowed to the pods matched by
+                                a NetworkPolicySpec's podSelector. The traffic must
+                                match both ports and from.
                               properties:
                                 from:
-                                  description: List of sources which should be able to access the pods selected for this rule. Items in this list are combined using a logical OR operation. If this field is empty or missing, this rule matches all sources (traffic not restricted by source). If this field is present and contains at least one item, this rule allows traffic only if the traffic matches at least one item in the from list.
+                                  description: List of sources which should be able
+                                    to access the pods selected for this rule. Items
+                                    in this list are combined using a logical OR operation.
+                                    If this field is empty or missing, this rule matches
+                                    all sources (traffic not restricted by source).
+                                    If this field is present and contains at least one
+                                    item, this rule allows traffic only if the traffic
+                                    matches at least one item in the from list.
                                   items:
-                                    description: NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of fields are allowed
+                                    description: NetworkPolicyPeer describes a peer
+                                      to allow traffic to/from. Only certain combinations
+                                      of fields are allowed
                                     properties:
                                       ipBlock:
-                                        description: IPBlock defines policy on a particular IPBlock. If this field is set then neither of the other fields can be.
+                                        description: IPBlock defines policy on a particular
+                                          IPBlock. If this field is set then neither
+                                          of the other fields can be.
                                         properties:
                                           cidr:
-                                            description: CIDR is a string representing the IP Block Valid examples are "192.168.1.1/24" or "2001:db9::/64"
+                                            description: CIDR is a string representing
+                                              the IP Block Valid examples are "192.168.1.1/24"
+                                              or "2001:db9::/64"
                                             type: string
                                           except:
-                                            description: Except is a slice of CIDRs that should not be included within an IP Block Valid examples are "192.168.1.1/24" or "2001:db9::/64" Except values will be rejected if they are outside the CIDR range
+                                            description: Except is a slice of CIDRs
+                                              that should not be included within an
+                                              IP Block Valid examples are "192.168.1.1/24"
+                                              or "2001:db9::/64" Except values will
+                                              be rejected if they are outside the CIDR
+                                              range
                                             items:
                                               type: string
                                             type: array
@@ -949,21 +1443,45 @@ spec:
                                           - cidr
                                         type: object
                                       namespaceSelector:
-                                        description: "Selects Namespaces using cluster-scoped labels. This field follows standard label selector semantics; if present but empty, it selects all namespaces. \n If PodSelector is also set, then the NetworkPolicyPeer as a whole selects the Pods matching PodSelector in the Namespaces selected by NamespaceSelector. Otherwise it selects all Pods in the Namespaces selected by NamespaceSelector."
+                                        description: "Selects Namespaces using cluster-scoped
+                                        labels. This field follows standard label
+                                        selector semantics; if present but empty,
+                                        it selects all namespaces. \n If PodSelector
+                                        is also set, then the NetworkPolicyPeer as
+                                        a whole selects the Pods matching PodSelector
+                                        in the Namespaces selected by NamespaceSelector.
+                                        Otherwise it selects all Pods in the Namespaces
+                                        selected by NamespaceSelector."
                                         properties:
                                           matchExpressions:
-                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The requirements
+                                              are ANDed.
                                             items:
-                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
                                               properties:
                                                 key:
-                                                  description: key is the label key that the selector applies to.
+                                                  description: key is the label key
+                                                    that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  description: operator represents a
+                                                    key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists
+                                                    and DoesNotExist.
                                                   type: string
                                                 values:
-                                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                  description: values is an array of
+                                                    string values. If the operator is
+                                                    In or NotIn, the values array must
+                                                    be non-empty. If the operator is
+                                                    Exists or DoesNotExist, the values
+                                                    array must be empty. This array
+                                                    is replaced during a strategic merge
+                                                    patch.
                                                   items:
                                                     type: string
                                                   type: array
@@ -975,26 +1493,55 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       podSelector:
-                                        description: "This is a label selector which selects Pods. This field follows standard label selector semantics; if present but empty, it selects all pods. \n If NamespaceSelector is also set, then the NetworkPolicyPeer as a whole selects the Pods matching PodSelector in the Namespaces selected by NamespaceSelector. Otherwise it selects the Pods matching PodSelector in the policy's own Namespace."
+                                        description: "This is a label selector which
+                                        selects Pods. This field follows standard
+                                        label selector semantics; if present but empty,
+                                        it selects all pods. \n If NamespaceSelector
+                                        is also set, then the NetworkPolicyPeer as
+                                        a whole selects the Pods matching PodSelector
+                                        in the Namespaces selected by NamespaceSelector.
+                                        Otherwise it selects the Pods matching PodSelector
+                                        in the policy's own Namespace."
                                         properties:
                                           matchExpressions:
-                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The requirements
+                                              are ANDed.
                                             items:
-                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
                                               properties:
                                                 key:
-                                                  description: key is the label key that the selector applies to.
+                                                  description: key is the label key
+                                                    that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  description: operator represents a
+                                                    key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists
+                                                    and DoesNotExist.
                                                   type: string
                                                 values:
-                                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                  description: values is an array of
+                                                    string values. If the operator is
+                                                    In or NotIn, the values array must
+                                                    be non-empty. If the operator is
+                                                    Exists or DoesNotExist, the values
+                                                    array must be empty. This array
+                                                    is replaced during a strategic merge
+                                                    patch.
                                                   items:
                                                     type: string
                                                   type: array
@@ -1006,51 +1553,96 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
                                     type: object
                                   type: array
                                 ports:
-                                  description: List of ports which should be made accessible on the pods selected for this rule. Each item in this list is combined using a logical OR. If this field is empty or missing, this rule matches all ports (traffic not restricted by port). If this field is present and contains at least one item, then this rule allows traffic only if the traffic matches at least one port in the list.
+                                  description: List of ports which should be made accessible
+                                    on the pods selected for this rule. Each item in
+                                    this list is combined using a logical OR. If this
+                                    field is empty or missing, this rule matches all
+                                    ports (traffic not restricted by port). If this
+                                    field is present and contains at least one item,
+                                    then this rule allows traffic only if the traffic
+                                    matches at least one port in the list.
                                   items:
-                                    description: NetworkPolicyPort describes a port to allow traffic on
+                                    description: NetworkPolicyPort describes a port
+                                      to allow traffic on
                                     properties:
                                       endPort:
-                                        description: If set, indicates that the range of ports from port to endPort, inclusive, should be allowed by the policy. This field cannot be defined if the port field is not defined or if the port field is defined as a named (string) port. The endPort must be equal or greater than port. This feature is in Beta state and is enabled by default. It can be disabled using the Feature Gate "NetworkPolicyEndPort".
+                                        description: If set, indicates that the range
+                                          of ports from port to endPort, inclusive,
+                                          should be allowed by the policy. This field
+                                          cannot be defined if the port field is not
+                                          defined or if the port field is defined as
+                                          a named (string) port. The endPort must be
+                                          equal or greater than port. This feature is
+                                          in Beta state and is enabled by default. It
+                                          can be disabled using the Feature Gate "NetworkPolicyEndPort".
                                         format: int32
                                         type: integer
                                       port:
                                         anyOf:
                                           - type: integer
                                           - type: string
-                                        description: The port on the given protocol. This can either be a numerical or named port on a pod. If this field is not provided, this matches all port names and numbers. If present, only traffic on the specified protocol AND port will be matched.
+                                        description: The port on the given protocol.
+                                          This can either be a numerical or named port
+                                          on a pod. If this field is not provided, this
+                                          matches all port names and numbers. If present,
+                                          only traffic on the specified protocol AND
+                                          port will be matched.
                                         x-kubernetes-int-or-string: true
                                       protocol:
                                         default: TCP
-                                        description: The protocol (TCP, UDP, or SCTP) which traffic must match. If not specified, this field defaults to TCP.
+                                        description: The protocol (TCP, UDP, or SCTP)
+                                          which traffic must match. If not specified,
+                                          this field defaults to TCP.
                                         type: string
                                     type: object
                                   type: array
                               type: object
                             type: array
                           podSelector:
-                            description: Selects the pods to which this NetworkPolicy object applies. The array of ingress rules is applied to any pods selected by this field. Multiple network policies can select the same set of pods. In this case, the ingress rules for each are combined additively. This field is NOT optional and follows standard label selector semantics. An empty podSelector matches all pods in this namespace.
+                            description: Selects the pods to which this NetworkPolicy
+                              object applies. The array of ingress rules is applied
+                              to any pods selected by this field. Multiple network policies
+                              can select the same set of pods. In this case, the ingress
+                              rules for each are combined additively. This field is
+                              NOT optional and follows standard label selector semantics.
+                              An empty podSelector matches all pods in this namespace.
                             properties:
                               matchExpressions:
-                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
                                 items:
-                                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                  description: A label selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
                                   properties:
                                     key:
-                                      description: key is the label key that the selector applies to.
+                                      description: key is the label key that the selector
+                                        applies to.
                                       type: string
                                     operator:
-                                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      description: operator represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists and DoesNotExist.
                                       type: string
                                     values:
-                                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                      description: values is an array of string values.
+                                        If the operator is In or NotIn, the values array
+                                        must be non-empty. If the operator is Exists
+                                        or DoesNotExist, the values array must be empty.
+                                        This array is replaced during a strategic merge
+                                        patch.
                                       items:
                                         type: string
                                       type: array
@@ -1062,14 +1654,32 @@ spec:
                               matchLabels:
                                 additionalProperties:
                                   type: string
-                                description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                description: matchLabels is a map of {key,value} pairs.
+                                  A single {key,value} in the matchLabels map is equivalent
+                                  to an element of matchExpressions, whose key field
+                                  is "key", the operator is "In", and the values array
+                                  contains only "value". The requirements are ANDed.
                                 type: object
                             type: object
                             x-kubernetes-map-type: atomic
                           policyTypes:
-                            description: List of rule types that the NetworkPolicy relates to. Valid options are ["Ingress"], ["Egress"], or ["Ingress", "Egress"]. If this field is not specified, it will default based on the existence of Ingress or Egress rules; policies that contain an Egress section are assumed to affect Egress, and all policies (whether or not they contain an Ingress section) are assumed to affect Ingress. If you want to write an egress-only policy, you must explicitly specify policyTypes [ "Egress" ]. Likewise, if you want to write a policy that specifies that no egress is allowed, you must specify a policyTypes value that include "Egress" (since such a policy would not include an Egress section and would otherwise default to just [ "Ingress" ]). This field is beta-level in 1.8
+                            description: List of rule types that the NetworkPolicy relates
+                              to. Valid options are ["Ingress"], ["Egress"], or ["Ingress",
+                              "Egress"]. If this field is not specified, it will default
+                              based on the existence of Ingress or Egress rules; policies
+                              that contain an Egress section are assumed to affect Egress,
+                              and all policies (whether or not they contain an Ingress
+                              section) are assumed to affect Ingress. If you want to
+                              write an egress-only policy, you must explicitly specify
+                              policyTypes [ "Egress" ]. Likewise, if you want to write
+                              a policy that specifies that no egress is allowed, you
+                              must specify a policyTypes value that include "Egress"
+                              (since such a policy would not include an Egress section
+                              and would otherwise default to just [ "Ingress" ]). This
+                              field is beta-level in 1.8
                             items:
-                              description: PolicyType string describes the NetworkPolicy type This type is beta-level in 1.8
+                              description: PolicyType string describes the NetworkPolicy
+                                type This type is beta-level in 1.8
                               type: string
                             type: array
                         required:
@@ -1080,14 +1690,19 @@ spec:
                 nodeSelector:
                   additionalProperties:
                     type: string
-                  description: Specifies the label to control the placement of pods on a given pool of worker nodes. All namespaces created within the Tenant will have the node selector annotation. This annotation tells the Kubernetes scheduler to place pods on the nodes having the selector label. Optional.
+                  description: Specifies the label to control the placement of pods
+                    on a given pool of worker nodes. All namespaces created within the
+                    Tenant will have the node selector annotation. This annotation tells
+                    the Kubernetes scheduler to place pods on the nodes having the selector
+                    label. Optional.
                   type: object
                 owners:
                   description: Specifies the owners of the Tenant. Mandatory.
                   items:
                     properties:
                       kind:
-                        description: Kind of tenant owner. Possible values are "User", "Group", and "ServiceAccount"
+                        description: Kind of tenant owner. Possible values are "User",
+                          "Group", and "ServiceAccount"
                         enum:
                           - User
                           - Group
@@ -1126,7 +1741,9 @@ spec:
                     type: object
                   type: array
                 priorityClasses:
-                  description: Specifies the allowed priorityClasses assigned to the Tenant. Capsule assures that all Pods resources created in the Tenant can use only one of the allowed PriorityClasses. Optional.
+                  description: Specifies the allowed priorityClasses assigned to the
+                    Tenant. Capsule assures that all Pods resources created in the Tenant
+                    can use only one of the allowed PriorityClasses. Optional.
                   properties:
                     allowed:
                       items:
@@ -1136,11 +1753,17 @@ spec:
                       type: string
                   type: object
                 resourceQuotas:
-                  description: Specifies a list of ResourceQuota resources assigned to the Tenant. The assigned values are inherited by any namespace created in the Tenant. The Capsule operator aggregates ResourceQuota at Tenant level, so that the hard quota is never crossed for the given Tenant. This permits the Tenant owner to consume resources in the Tenant regardless of the namespace. Optional.
+                  description: Specifies a list of ResourceQuota resources assigned
+                    to the Tenant. The assigned values are inherited by any namespace
+                    created in the Tenant. The Capsule operator aggregates ResourceQuota
+                    at Tenant level, so that the hard quota is never crossed for the
+                    given Tenant. This permits the Tenant owner to consume resources
+                    in the Tenant regardless of the namespace. Optional.
                   properties:
                     items:
                       items:
-                        description: ResourceQuotaSpec defines the desired hard limits to enforce for Quota.
+                        description: ResourceQuotaSpec defines the desired hard limits
+                          to enforce for Quota.
                         properties:
                           hard:
                             additionalProperties:
@@ -1149,24 +1772,40 @@ spec:
                                 - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: 'hard is the set of desired hard limits for each named resource. More info: https://kubernetes.io/docs/concepts/policy/resource-quotas/'
+                            description: 'hard is the set of desired hard limits for
+                            each named resource. More info: https://kubernetes.io/docs/concepts/policy/resource-quotas/'
                             type: object
                           scopeSelector:
-                            description: scopeSelector is also a collection of filters like scopes that must match each object tracked by a quota but expressed using ScopeSelectorOperator in combination with possible values. For a resource to match, both scopes AND scopeSelector (if specified in spec), must be matched.
+                            description: scopeSelector is also a collection of filters
+                              like scopes that must match each object tracked by a quota
+                              but expressed using ScopeSelectorOperator in combination
+                              with possible values. For a resource to match, both scopes
+                              AND scopeSelector (if specified in spec), must be matched.
                             properties:
                               matchExpressions:
-                                description: A list of scope selector requirements by scope of the resources.
+                                description: A list of scope selector requirements by
+                                  scope of the resources.
                                 items:
-                                  description: A scoped-resource selector requirement is a selector that contains values, a scope name, and an operator that relates the scope name and values.
+                                  description: A scoped-resource selector requirement
+                                    is a selector that contains values, a scope name,
+                                    and an operator that relates the scope name and
+                                    values.
                                   properties:
                                     operator:
-                                      description: Represents a scope's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist.
+                                      description: Represents a scope's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists, DoesNotExist.
                                       type: string
                                     scopeName:
-                                      description: The name of the scope that the selector applies to.
+                                      description: The name of the scope that the selector
+                                        applies to.
                                       type: string
                                     values:
-                                      description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                      description: An array of string values. If the
+                                        operator is In or NotIn, the values array must
+                                        be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This array is
+                                        replaced during a strategic merge patch.
                                       items:
                                         type: string
                                       type: array
@@ -1178,26 +1817,33 @@ spec:
                             type: object
                             x-kubernetes-map-type: atomic
                           scopes:
-                            description: A collection of filters that must match each object tracked by a quota. If not specified, the quota matches all objects.
+                            description: A collection of filters that must match each
+                              object tracked by a quota. If not specified, the quota
+                              matches all objects.
                             items:
-                              description: A ResourceQuotaScope defines a filter that must match each object tracked by a quota
+                              description: A ResourceQuotaScope defines a filter that
+                                must match each object tracked by a quota
                               type: string
                             type: array
                         type: object
                       type: array
                     scope:
                       default: Tenant
-                      description: Define if the Resource Budget should compute resource across all Namespaces in the Tenant or individually per cluster. Default is Tenant
+                      description: Define if the Resource Budget should compute resource
+                        across all Namespaces in the Tenant or individually per cluster.
+                        Default is Tenant
                       enum:
                         - Tenant
                         - Namespace
                       type: string
                   type: object
                 serviceOptions:
-                  description: Specifies options for the Service, such as additional metadata or block of certain type of Services. Optional.
+                  description: Specifies options for the Service, such as additional
+                    metadata or block of certain type of Services. Optional.
                   properties:
                     additionalMetadata:
-                      description: Specifies additional labels and annotations the Capsule operator places on any Service resource in the Tenant. Optional.
+                      description: Specifies additional labels and annotations the Capsule
+                        operator places on any Service resource in the Tenant. Optional.
                       properties:
                         annotations:
                           additionalProperties:
@@ -1213,19 +1859,24 @@ spec:
                       properties:
                         externalName:
                           default: true
-                          description: Specifies if ExternalName service type resources are allowed for the Tenant. Default is true. Optional.
+                          description: Specifies if ExternalName service type resources
+                            are allowed for the Tenant. Default is true. Optional.
                           type: boolean
                         loadBalancer:
                           default: true
-                          description: Specifies if LoadBalancer service type resources are allowed for the Tenant. Default is true. Optional.
+                          description: Specifies if LoadBalancer service type resources
+                            are allowed for the Tenant. Default is true. Optional.
                           type: boolean
                         nodePort:
                           default: true
-                          description: Specifies if NodePort service type resources are allowed for the Tenant. Default is true. Optional.
+                          description: Specifies if NodePort service type resources
+                            are allowed for the Tenant. Default is true. Optional.
                           type: boolean
                       type: object
                     externalIPs:
-                      description: Specifies the external IPs that can be used in Services with type ClusterIP. An empty list means no IPs are allowed. Optional.
+                      description: Specifies the external IPs that can be used in Services
+                        with type ClusterIP. An empty list means no IPs are allowed.
+                        Optional.
                       properties:
                         allowed:
                           items:
@@ -1237,7 +1888,10 @@ spec:
                       type: object
                   type: object
                 storageClasses:
-                  description: Specifies the allowed StorageClasses assigned to the Tenant. Capsule assures that all PersistentVolumeClaim resources created in the Tenant can use only one of the allowed StorageClasses. Optional.
+                  description: Specifies the allowed StorageClasses assigned to the
+                    Tenant. Capsule assures that all PersistentVolumeClaim resources
+                    created in the Tenant can use only one of the allowed StorageClasses.
+                    Optional.
                   properties:
                     allowed:
                       items:
@@ -1262,7 +1916,8 @@ spec:
                   type: integer
                 state:
                   default: Active
-                  description: The operational state of the Tenant. Possible values are "Active", "Cordoned".
+                  description: The operational state of the Tenant. Possible values
+                    are "Active", "Cordoned".
                   enum:
                     - Cordoned
                     - Active
@@ -1303,10 +1958,14 @@ spec:
           description: Tenant is the Schema for the tenants API.
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
               type: string
             metadata:
               type: object
@@ -1314,7 +1973,9 @@ spec:
               description: TenantSpec defines the desired state of Tenant.
               properties:
                 additionalRoleBindings:
-                  description: Specifies additional RoleBindings assigned to the Tenant. Capsule will ensure that all namespaces in the Tenant always contain the RoleBinding for the given ClusterRole. Optional.
+                  description: Specifies additional RoleBindings assigned to the Tenant.
+                    Capsule will ensure that all namespaces in the Tenant always contain
+                    the RoleBinding for the given ClusterRole. Optional.
                   items:
                     properties:
                       clusterRoleName:
@@ -1322,19 +1983,31 @@ spec:
                       subjects:
                         description: kubebuilder:validation:Minimum=1
                         items:
-                          description: Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.
+                          description: Subject contains a reference to the object or
+                            user identities a role binding applies to.  This can either
+                            hold a direct API object reference, or a value for non-objects
+                            such as user and group names.
                           properties:
                             apiGroup:
-                              description: APIGroup holds the API group of the referenced subject. Defaults to "" for ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
+                              description: APIGroup holds the API group of the referenced
+                                subject. Defaults to "" for ServiceAccount subjects.
+                                Defaults to "rbac.authorization.k8s.io" for User and
+                                Group subjects.
                               type: string
                             kind:
-                              description: Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount". If the Authorizer does not recognized the kind value, the Authorizer should report an error.
+                              description: Kind of object being referenced. Values defined
+                                by this API group are "User", "Group", and "ServiceAccount".
+                                If the Authorizer does not recognized the kind value,
+                                the Authorizer should report an error.
                               type: string
                             name:
                               description: Name of the object being referenced.
                               type: string
                             namespace:
-                              description: Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty the Authorizer should report an error.
+                              description: Namespace of the referenced object.  If the
+                                object kind is non-namespace, such as "User" or "Group",
+                                and this value is not empty the Authorizer should report
+                                an error.
                               type: string
                           required:
                             - kind
@@ -1348,7 +2021,9 @@ spec:
                     type: object
                   type: array
                 containerRegistries:
-                  description: Specifies the trusted Image Registries assigned to the Tenant. Capsule assures that all Pods resources created in the Tenant can use only one of the allowed trusted registries. Optional.
+                  description: Specifies the trusted Image Registries assigned to the
+                    Tenant. Capsule assures that all Pods resources created in the Tenant
+                    can use only one of the allowed trusted registries. Optional.
                   properties:
                     allowed:
                       items:
@@ -1358,10 +2033,13 @@ spec:
                       type: string
                   type: object
                 cordoned:
-                  description: Toggling the Tenant resources cordoning, when enable resources cannot be deleted.
+                  description: Toggling the Tenant resources cordoning, when enable
+                    resources cannot be deleted.
                   type: boolean
                 imagePullPolicies:
-                  description: Specify the allowed values for the imagePullPolicies option in Pod resources. Capsule assures that all Pod resources created in the Tenant can use only one of the allowed policy. Optional.
+                  description: Specify the allowed values for the imagePullPolicies
+                    option in Pod resources. Capsule assures that all Pod resources
+                    created in the Tenant can use only one of the allowed policy. Optional.
                   items:
                     enum:
                       - Always
@@ -1370,13 +2048,19 @@ spec:
                     type: string
                   type: array
                 ingressOptions:
-                  description: Specifies options for the Ingress resources, such as allowed hostnames and IngressClass. Optional.
+                  description: Specifies options for the Ingress resources, such as
+                    allowed hostnames and IngressClass. Optional.
                   properties:
                     allowWildcardHostnames:
-                      description: Toggles the ability for Ingress resources created in a Tenant to have a hostname wildcard.
+                      description: Toggles the ability for Ingress resources created
+                        in a Tenant to have a hostname wildcard.
                       type: boolean
                     allowedClasses:
-                      description: Specifies the allowed IngressClasses assigned to the Tenant. Capsule assures that all Ingress resources created in the Tenant can use only one of the allowed IngressClasses. A default value can be specified, and all the Ingress resources created will inherit the declared class. Optional.
+                      description: Specifies the allowed IngressClasses assigned to
+                        the Tenant. Capsule assures that all Ingress resources created
+                        in the Tenant can use only one of the allowed IngressClasses.
+                        A default value can be specified, and all the Ingress resources
+                        created will inherit the declared class. Optional.
                       properties:
                         allowed:
                           items:
@@ -1387,18 +2071,28 @@ spec:
                         default:
                           type: string
                         matchExpressions:
-                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                          description: matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
                           items:
-                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                            description: A label selector requirement is a selector
+                              that contains values, a key, and an operator that relates
+                              the key and values.
                             properties:
                               key:
-                                description: key is the label key that the selector applies to.
+                                description: key is the label key that the selector
+                                  applies to.
                                 type: string
                               operator:
-                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                description: operator represents a key's relationship
+                                  to a set of values. Valid operators are In, NotIn,
+                                  Exists and DoesNotExist.
                                 type: string
                               values:
-                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                description: values is an array of string values. If
+                                  the operator is In or NotIn, the values array must
+                                  be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced
+                                  during a strategic merge patch.
                                 items:
                                   type: string
                                 type: array
@@ -1410,12 +2104,19 @@ spec:
                         matchLabels:
                           additionalProperties:
                             type: string
-                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          description: matchLabels is a map of {key,value} pairs. A
+                            single {key,value} in the matchLabels map is equivalent
+                            to an element of matchExpressions, whose key field is "key",
+                            the operator is "In", and the values array contains only
+                            "value". The requirements are ANDed.
                           type: object
                       type: object
                       x-kubernetes-map-type: atomic
                     allowedHostnames:
-                      description: Specifies the allowed hostnames in Ingresses for the given Tenant. Capsule assures that all Ingress resources created in the Tenant can use only one of the allowed hostnames. Optional.
+                      description: Specifies the allowed hostnames in Ingresses for
+                        the given Tenant. Capsule assures that all Ingress resources
+                        created in the Tenant can use only one of the allowed hostnames.
+                        Optional.
                       properties:
                         allowed:
                           items:
@@ -1426,7 +2127,15 @@ spec:
                       type: object
                     hostnameCollisionScope:
                       default: Disabled
-                      description: "Defines the scope of hostname collision check performed when Tenant Owners create Ingress with allowed hostnames. \n - Cluster: disallow the creation of an Ingress if the pair hostname and path is already used across the Namespaces managed by Capsule. \n - Tenant: disallow the creation of an Ingress if the pair hostname and path is already used across the Namespaces of the Tenant. \n - Namespace: disallow the creation of an Ingress if the pair hostname and path is already used in the Ingress Namespace. \n Optional."
+                      description: "Defines the scope of hostname collision check performed
+                      when Tenant Owners create Ingress with allowed hostnames. \n
+                      - Cluster: disallow the creation of an Ingress if the pair hostname
+                      and path is already used across the Namespaces managed by Capsule.
+                      \n - Tenant: disallow the creation of an Ingress if the pair
+                      hostname and path is already used across the Namespaces of the
+                      Tenant. \n - Namespace: disallow the creation of an Ingress
+                      if the pair hostname and path is already used in the Ingress
+                      Namespace. \n Optional."
                       enum:
                         - Cluster
                         - Tenant
@@ -1435,16 +2144,21 @@ spec:
                       type: string
                   type: object
                 limitRanges:
-                  description: Specifies the resource min/max usage restrictions to the Tenant. The assigned values are inherited by any namespace created in the Tenant. Optional.
+                  description: Specifies the resource min/max usage restrictions to
+                    the Tenant. The assigned values are inherited by any namespace created
+                    in the Tenant. Optional.
                   properties:
                     items:
                       items:
-                        description: LimitRangeSpec defines a min/max usage limit for resources that match on kind.
+                        description: LimitRangeSpec defines a min/max usage limit for
+                          resources that match on kind.
                         properties:
                           limits:
-                            description: Limits is the list of LimitRangeItem objects that are enforced.
+                            description: Limits is the list of LimitRangeItem objects
+                              that are enforced.
                             items:
-                              description: LimitRangeItem defines a min/max usage limit for any resource that matches on kind.
+                              description: LimitRangeItem defines a min/max usage limit
+                                for any resource that matches on kind.
                               properties:
                                 default:
                                   additionalProperties:
@@ -1453,7 +2167,8 @@ spec:
                                       - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
-                                  description: Default resource requirement limit value by resource name if resource limit is omitted.
+                                  description: Default resource requirement limit value
+                                    by resource name if resource limit is omitted.
                                   type: object
                                 defaultRequest:
                                   additionalProperties:
@@ -1462,7 +2177,9 @@ spec:
                                       - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
-                                  description: DefaultRequest is the default resource requirement request value by resource name if resource request is omitted.
+                                  description: DefaultRequest is the default resource
+                                    requirement request value by resource name if resource
+                                    request is omitted.
                                   type: object
                                 max:
                                   additionalProperties:
@@ -1471,7 +2188,8 @@ spec:
                                       - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
-                                  description: Max usage constraints on this kind by resource name.
+                                  description: Max usage constraints on this kind by
+                                    resource name.
                                   type: object
                                 maxLimitRequestRatio:
                                   additionalProperties:
@@ -1480,7 +2198,11 @@ spec:
                                       - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
-                                  description: MaxLimitRequestRatio if specified, the named resource must have a request and limit that are both non-zero where limit divided by request is less than or equal to the enumerated value; this represents the max burst for the named resource.
+                                  description: MaxLimitRequestRatio if specified, the
+                                    named resource must have a request and limit that
+                                    are both non-zero where limit divided by request
+                                    is less than or equal to the enumerated value; this
+                                    represents the max burst for the named resource.
                                   type: object
                                 min:
                                   additionalProperties:
@@ -1489,10 +2211,12 @@ spec:
                                       - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
-                                  description: Min usage constraints on this kind by resource name.
+                                  description: Min usage constraints on this kind by
+                                    resource name.
                                   type: object
                                 type:
-                                  description: Type of resource that this limit applies to.
+                                  description: Type of resource that this limit applies
+                                    to.
                                   type: string
                               required:
                                 - type
@@ -1504,10 +2228,14 @@ spec:
                       type: array
                   type: object
                 namespaceOptions:
-                  description: Specifies options for the Namespaces, such as additional metadata or maximum number of namespaces allowed for that Tenant. Once the namespace quota assigned to the Tenant has been reached, the Tenant owner cannot create further namespaces. Optional.
+                  description: Specifies options for the Namespaces, such as additional
+                    metadata or maximum number of namespaces allowed for that Tenant.
+                    Once the namespace quota assigned to the Tenant has been reached,
+                    the Tenant owner cannot create further namespaces. Optional.
                   properties:
                     additionalMetadata:
-                      description: Specifies additional labels and annotations the Capsule operator places on any Namespace resource in the Tenant. Optional.
+                      description: Specifies additional labels and annotations the Capsule
+                        operator places on any Namespace resource in the Tenant. Optional.
                       properties:
                         annotations:
                           additionalProperties:
@@ -1519,7 +2247,8 @@ spec:
                           type: object
                       type: object
                     forbiddenAnnotations:
-                      description: Define the annotations that a Tenant Owner cannot set for their Namespace resources.
+                      description: Define the annotations that a Tenant Owner cannot
+                        set for their Namespace resources.
                       properties:
                         denied:
                           items:
@@ -1529,7 +2258,8 @@ spec:
                           type: string
                       type: object
                     forbiddenLabels:
-                      description: Define the labels that a Tenant Owner cannot set for their Namespace resources.
+                      description: Define the labels that a Tenant Owner cannot set
+                        for their Namespace resources.
                       properties:
                         denied:
                           items:
@@ -1539,57 +2269,116 @@ spec:
                           type: string
                       type: object
                     quota:
-                      description: Specifies the maximum number of namespaces allowed for that Tenant. Once the namespace quota assigned to the Tenant has been reached, the Tenant owner cannot create further namespaces. Optional.
+                      description: Specifies the maximum number of namespaces allowed
+                        for that Tenant. Once the namespace quota assigned to the Tenant
+                        has been reached, the Tenant owner cannot create further namespaces.
+                        Optional.
                       format: int32
                       minimum: 1
                       type: integer
                   type: object
                 networkPolicies:
-                  description: Specifies the NetworkPolicies assigned to the Tenant. The assigned NetworkPolicies are inherited by any namespace created in the Tenant. Optional.
+                  description: Specifies the NetworkPolicies assigned to the Tenant.
+                    The assigned NetworkPolicies are inherited by any namespace created
+                    in the Tenant. Optional.
                   properties:
                     items:
                       items:
-                        description: NetworkPolicySpec provides the specification of a NetworkPolicy
+                        description: NetworkPolicySpec provides the specification of
+                          a NetworkPolicy
                         properties:
                           egress:
-                            description: List of egress rules to be applied to the selected pods. Outgoing traffic is allowed if there are no NetworkPolicies selecting the pod (and cluster policy otherwise allows the traffic), OR if the traffic matches at least one egress rule across all of the NetworkPolicy objects whose podSelector matches the pod. If this field is empty then this NetworkPolicy limits all outgoing traffic (and serves solely to ensure that the pods it selects are isolated by default). This field is beta-level in 1.8
+                            description: List of egress rules to be applied to the selected
+                              pods. Outgoing traffic is allowed if there are no NetworkPolicies
+                              selecting the pod (and cluster policy otherwise allows
+                              the traffic), OR if the traffic matches at least one egress
+                              rule across all of the NetworkPolicy objects whose podSelector
+                              matches the pod. If this field is empty then this NetworkPolicy
+                              limits all outgoing traffic (and serves solely to ensure
+                              that the pods it selects are isolated by default). This
+                              field is beta-level in 1.8
                             items:
-                              description: NetworkPolicyEgressRule describes a particular set of traffic that is allowed out of pods matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and to. This type is beta-level in 1.8
+                              description: NetworkPolicyEgressRule describes a particular
+                                set of traffic that is allowed out of pods matched by
+                                a NetworkPolicySpec's podSelector. The traffic must
+                                match both ports and to. This type is beta-level in
+                                1.8
                               properties:
                                 ports:
-                                  description: List of destination ports for outgoing traffic. Each item in this list is combined using a logical OR. If this field is empty or missing, this rule matches all ports (traffic not restricted by port). If this field is present and contains at least one item, then this rule allows traffic only if the traffic matches at least one port in the list.
+                                  description: List of destination ports for outgoing
+                                    traffic. Each item in this list is combined using
+                                    a logical OR. If this field is empty or missing,
+                                    this rule matches all ports (traffic not restricted
+                                    by port). If this field is present and contains
+                                    at least one item, then this rule allows traffic
+                                    only if the traffic matches at least one port in
+                                    the list.
                                   items:
-                                    description: NetworkPolicyPort describes a port to allow traffic on
+                                    description: NetworkPolicyPort describes a port
+                                      to allow traffic on
                                     properties:
                                       endPort:
-                                        description: If set, indicates that the range of ports from port to endPort, inclusive, should be allowed by the policy. This field cannot be defined if the port field is not defined or if the port field is defined as a named (string) port. The endPort must be equal or greater than port. This feature is in Beta state and is enabled by default. It can be disabled using the Feature Gate "NetworkPolicyEndPort".
+                                        description: If set, indicates that the range
+                                          of ports from port to endPort, inclusive,
+                                          should be allowed by the policy. This field
+                                          cannot be defined if the port field is not
+                                          defined or if the port field is defined as
+                                          a named (string) port. The endPort must be
+                                          equal or greater than port. This feature is
+                                          in Beta state and is enabled by default. It
+                                          can be disabled using the Feature Gate "NetworkPolicyEndPort".
                                         format: int32
                                         type: integer
                                       port:
                                         anyOf:
                                           - type: integer
                                           - type: string
-                                        description: The port on the given protocol. This can either be a numerical or named port on a pod. If this field is not provided, this matches all port names and numbers. If present, only traffic on the specified protocol AND port will be matched.
+                                        description: The port on the given protocol.
+                                          This can either be a numerical or named port
+                                          on a pod. If this field is not provided, this
+                                          matches all port names and numbers. If present,
+                                          only traffic on the specified protocol AND
+                                          port will be matched.
                                         x-kubernetes-int-or-string: true
                                       protocol:
                                         default: TCP
-                                        description: The protocol (TCP, UDP, or SCTP) which traffic must match. If not specified, this field defaults to TCP.
+                                        description: The protocol (TCP, UDP, or SCTP)
+                                          which traffic must match. If not specified,
+                                          this field defaults to TCP.
                                         type: string
                                     type: object
                                   type: array
                                 to:
-                                  description: List of destinations for outgoing traffic of pods selected for this rule. Items in this list are combined using a logical OR operation. If this field is empty or missing, this rule matches all destinations (traffic not restricted by destination). If this field is present and contains at least one item, this rule allows traffic only if the traffic matches at least one item in the to list.
+                                  description: List of destinations for outgoing traffic
+                                    of pods selected for this rule. Items in this list
+                                    are combined using a logical OR operation. If this
+                                    field is empty or missing, this rule matches all
+                                    destinations (traffic not restricted by destination).
+                                    If this field is present and contains at least one
+                                    item, this rule allows traffic only if the traffic
+                                    matches at least one item in the to list.
                                   items:
-                                    description: NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of fields are allowed
+                                    description: NetworkPolicyPeer describes a peer
+                                      to allow traffic to/from. Only certain combinations
+                                      of fields are allowed
                                     properties:
                                       ipBlock:
-                                        description: IPBlock defines policy on a particular IPBlock. If this field is set then neither of the other fields can be.
+                                        description: IPBlock defines policy on a particular
+                                          IPBlock. If this field is set then neither
+                                          of the other fields can be.
                                         properties:
                                           cidr:
-                                            description: CIDR is a string representing the IP Block Valid examples are "192.168.1.1/24" or "2001:db9::/64"
+                                            description: CIDR is a string representing
+                                              the IP Block Valid examples are "192.168.1.1/24"
+                                              or "2001:db9::/64"
                                             type: string
                                           except:
-                                            description: Except is a slice of CIDRs that should not be included within an IP Block Valid examples are "192.168.1.1/24" or "2001:db9::/64" Except values will be rejected if they are outside the CIDR range
+                                            description: Except is a slice of CIDRs
+                                              that should not be included within an
+                                              IP Block Valid examples are "192.168.1.1/24"
+                                              or "2001:db9::/64" Except values will
+                                              be rejected if they are outside the CIDR
+                                              range
                                             items:
                                               type: string
                                             type: array
@@ -1597,21 +2386,45 @@ spec:
                                           - cidr
                                         type: object
                                       namespaceSelector:
-                                        description: "Selects Namespaces using cluster-scoped labels. This field follows standard label selector semantics; if present but empty, it selects all namespaces. \n If PodSelector is also set, then the NetworkPolicyPeer as a whole selects the Pods matching PodSelector in the Namespaces selected by NamespaceSelector. Otherwise it selects all Pods in the Namespaces selected by NamespaceSelector."
+                                        description: "Selects Namespaces using cluster-scoped
+                                        labels. This field follows standard label
+                                        selector semantics; if present but empty,
+                                        it selects all namespaces. \n If PodSelector
+                                        is also set, then the NetworkPolicyPeer as
+                                        a whole selects the Pods matching PodSelector
+                                        in the Namespaces selected by NamespaceSelector.
+                                        Otherwise it selects all Pods in the Namespaces
+                                        selected by NamespaceSelector."
                                         properties:
                                           matchExpressions:
-                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The requirements
+                                              are ANDed.
                                             items:
-                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
                                               properties:
                                                 key:
-                                                  description: key is the label key that the selector applies to.
+                                                  description: key is the label key
+                                                    that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  description: operator represents a
+                                                    key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists
+                                                    and DoesNotExist.
                                                   type: string
                                                 values:
-                                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                  description: values is an array of
+                                                    string values. If the operator is
+                                                    In or NotIn, the values array must
+                                                    be non-empty. If the operator is
+                                                    Exists or DoesNotExist, the values
+                                                    array must be empty. This array
+                                                    is replaced during a strategic merge
+                                                    patch.
                                                   items:
                                                     type: string
                                                   type: array
@@ -1623,26 +2436,55 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       podSelector:
-                                        description: "This is a label selector which selects Pods. This field follows standard label selector semantics; if present but empty, it selects all pods. \n If NamespaceSelector is also set, then the NetworkPolicyPeer as a whole selects the Pods matching PodSelector in the Namespaces selected by NamespaceSelector. Otherwise it selects the Pods matching PodSelector in the policy's own Namespace."
+                                        description: "This is a label selector which
+                                        selects Pods. This field follows standard
+                                        label selector semantics; if present but empty,
+                                        it selects all pods. \n If NamespaceSelector
+                                        is also set, then the NetworkPolicyPeer as
+                                        a whole selects the Pods matching PodSelector
+                                        in the Namespaces selected by NamespaceSelector.
+                                        Otherwise it selects the Pods matching PodSelector
+                                        in the policy's own Namespace."
                                         properties:
                                           matchExpressions:
-                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The requirements
+                                              are ANDed.
                                             items:
-                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
                                               properties:
                                                 key:
-                                                  description: key is the label key that the selector applies to.
+                                                  description: key is the label key
+                                                    that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  description: operator represents a
+                                                    key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists
+                                                    and DoesNotExist.
                                                   type: string
                                                 values:
-                                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                  description: values is an array of
+                                                    string values. If the operator is
+                                                    In or NotIn, the values array must
+                                                    be non-empty. If the operator is
+                                                    Exists or DoesNotExist, the values
+                                                    array must be empty. This array
+                                                    is replaced during a strategic merge
+                                                    patch.
                                                   items:
                                                     type: string
                                                   type: array
@@ -1654,7 +2496,12 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
@@ -1663,23 +2510,53 @@ spec:
                               type: object
                             type: array
                           ingress:
-                            description: List of ingress rules to be applied to the selected pods. Traffic is allowed to a pod if there are no NetworkPolicies selecting the pod (and cluster policy otherwise allows the traffic), OR if the traffic source is the pod's local node, OR if the traffic matches at least one ingress rule across all of the NetworkPolicy objects whose podSelector matches the pod. If this field is empty then this NetworkPolicy does not allow any traffic (and serves solely to ensure that the pods it selects are isolated by default)
+                            description: List of ingress rules to be applied to the
+                              selected pods. Traffic is allowed to a pod if there are
+                              no NetworkPolicies selecting the pod (and cluster policy
+                              otherwise allows the traffic), OR if the traffic source
+                              is the pod's local node, OR if the traffic matches at
+                              least one ingress rule across all of the NetworkPolicy
+                              objects whose podSelector matches the pod. If this field
+                              is empty then this NetworkPolicy does not allow any traffic
+                              (and serves solely to ensure that the pods it selects
+                              are isolated by default)
                             items:
-                              description: NetworkPolicyIngressRule describes a particular set of traffic that is allowed to the pods matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and from.
+                              description: NetworkPolicyIngressRule describes a particular
+                                set of traffic that is allowed to the pods matched by
+                                a NetworkPolicySpec's podSelector. The traffic must
+                                match both ports and from.
                               properties:
                                 from:
-                                  description: List of sources which should be able to access the pods selected for this rule. Items in this list are combined using a logical OR operation. If this field is empty or missing, this rule matches all sources (traffic not restricted by source). If this field is present and contains at least one item, this rule allows traffic only if the traffic matches at least one item in the from list.
+                                  description: List of sources which should be able
+                                    to access the pods selected for this rule. Items
+                                    in this list are combined using a logical OR operation.
+                                    If this field is empty or missing, this rule matches
+                                    all sources (traffic not restricted by source).
+                                    If this field is present and contains at least one
+                                    item, this rule allows traffic only if the traffic
+                                    matches at least one item in the from list.
                                   items:
-                                    description: NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of fields are allowed
+                                    description: NetworkPolicyPeer describes a peer
+                                      to allow traffic to/from. Only certain combinations
+                                      of fields are allowed
                                     properties:
                                       ipBlock:
-                                        description: IPBlock defines policy on a particular IPBlock. If this field is set then neither of the other fields can be.
+                                        description: IPBlock defines policy on a particular
+                                          IPBlock. If this field is set then neither
+                                          of the other fields can be.
                                         properties:
                                           cidr:
-                                            description: CIDR is a string representing the IP Block Valid examples are "192.168.1.1/24" or "2001:db9::/64"
+                                            description: CIDR is a string representing
+                                              the IP Block Valid examples are "192.168.1.1/24"
+                                              or "2001:db9::/64"
                                             type: string
                                           except:
-                                            description: Except is a slice of CIDRs that should not be included within an IP Block Valid examples are "192.168.1.1/24" or "2001:db9::/64" Except values will be rejected if they are outside the CIDR range
+                                            description: Except is a slice of CIDRs
+                                              that should not be included within an
+                                              IP Block Valid examples are "192.168.1.1/24"
+                                              or "2001:db9::/64" Except values will
+                                              be rejected if they are outside the CIDR
+                                              range
                                             items:
                                               type: string
                                             type: array
@@ -1687,21 +2564,45 @@ spec:
                                           - cidr
                                         type: object
                                       namespaceSelector:
-                                        description: "Selects Namespaces using cluster-scoped labels. This field follows standard label selector semantics; if present but empty, it selects all namespaces. \n If PodSelector is also set, then the NetworkPolicyPeer as a whole selects the Pods matching PodSelector in the Namespaces selected by NamespaceSelector. Otherwise it selects all Pods in the Namespaces selected by NamespaceSelector."
+                                        description: "Selects Namespaces using cluster-scoped
+                                        labels. This field follows standard label
+                                        selector semantics; if present but empty,
+                                        it selects all namespaces. \n If PodSelector
+                                        is also set, then the NetworkPolicyPeer as
+                                        a whole selects the Pods matching PodSelector
+                                        in the Namespaces selected by NamespaceSelector.
+                                        Otherwise it selects all Pods in the Namespaces
+                                        selected by NamespaceSelector."
                                         properties:
                                           matchExpressions:
-                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The requirements
+                                              are ANDed.
                                             items:
-                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
                                               properties:
                                                 key:
-                                                  description: key is the label key that the selector applies to.
+                                                  description: key is the label key
+                                                    that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  description: operator represents a
+                                                    key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists
+                                                    and DoesNotExist.
                                                   type: string
                                                 values:
-                                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                  description: values is an array of
+                                                    string values. If the operator is
+                                                    In or NotIn, the values array must
+                                                    be non-empty. If the operator is
+                                                    Exists or DoesNotExist, the values
+                                                    array must be empty. This array
+                                                    is replaced during a strategic merge
+                                                    patch.
                                                   items:
                                                     type: string
                                                   type: array
@@ -1713,26 +2614,55 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       podSelector:
-                                        description: "This is a label selector which selects Pods. This field follows standard label selector semantics; if present but empty, it selects all pods. \n If NamespaceSelector is also set, then the NetworkPolicyPeer as a whole selects the Pods matching PodSelector in the Namespaces selected by NamespaceSelector. Otherwise it selects the Pods matching PodSelector in the policy's own Namespace."
+                                        description: "This is a label selector which
+                                        selects Pods. This field follows standard
+                                        label selector semantics; if present but empty,
+                                        it selects all pods. \n If NamespaceSelector
+                                        is also set, then the NetworkPolicyPeer as
+                                        a whole selects the Pods matching PodSelector
+                                        in the Namespaces selected by NamespaceSelector.
+                                        Otherwise it selects the Pods matching PodSelector
+                                        in the policy's own Namespace."
                                         properties:
                                           matchExpressions:
-                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The requirements
+                                              are ANDed.
                                             items:
-                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
                                               properties:
                                                 key:
-                                                  description: key is the label key that the selector applies to.
+                                                  description: key is the label key
+                                                    that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  description: operator represents a
+                                                    key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists
+                                                    and DoesNotExist.
                                                   type: string
                                                 values:
-                                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                  description: values is an array of
+                                                    string values. If the operator is
+                                                    In or NotIn, the values array must
+                                                    be non-empty. If the operator is
+                                                    Exists or DoesNotExist, the values
+                                                    array must be empty. This array
+                                                    is replaced during a strategic merge
+                                                    patch.
                                                   items:
                                                     type: string
                                                   type: array
@@ -1744,51 +2674,96 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
                                     type: object
                                   type: array
                                 ports:
-                                  description: List of ports which should be made accessible on the pods selected for this rule. Each item in this list is combined using a logical OR. If this field is empty or missing, this rule matches all ports (traffic not restricted by port). If this field is present and contains at least one item, then this rule allows traffic only if the traffic matches at least one port in the list.
+                                  description: List of ports which should be made accessible
+                                    on the pods selected for this rule. Each item in
+                                    this list is combined using a logical OR. If this
+                                    field is empty or missing, this rule matches all
+                                    ports (traffic not restricted by port). If this
+                                    field is present and contains at least one item,
+                                    then this rule allows traffic only if the traffic
+                                    matches at least one port in the list.
                                   items:
-                                    description: NetworkPolicyPort describes a port to allow traffic on
+                                    description: NetworkPolicyPort describes a port
+                                      to allow traffic on
                                     properties:
                                       endPort:
-                                        description: If set, indicates that the range of ports from port to endPort, inclusive, should be allowed by the policy. This field cannot be defined if the port field is not defined or if the port field is defined as a named (string) port. The endPort must be equal or greater than port. This feature is in Beta state and is enabled by default. It can be disabled using the Feature Gate "NetworkPolicyEndPort".
+                                        description: If set, indicates that the range
+                                          of ports from port to endPort, inclusive,
+                                          should be allowed by the policy. This field
+                                          cannot be defined if the port field is not
+                                          defined or if the port field is defined as
+                                          a named (string) port. The endPort must be
+                                          equal or greater than port. This feature is
+                                          in Beta state and is enabled by default. It
+                                          can be disabled using the Feature Gate "NetworkPolicyEndPort".
                                         format: int32
                                         type: integer
                                       port:
                                         anyOf:
                                           - type: integer
                                           - type: string
-                                        description: The port on the given protocol. This can either be a numerical or named port on a pod. If this field is not provided, this matches all port names and numbers. If present, only traffic on the specified protocol AND port will be matched.
+                                        description: The port on the given protocol.
+                                          This can either be a numerical or named port
+                                          on a pod. If this field is not provided, this
+                                          matches all port names and numbers. If present,
+                                          only traffic on the specified protocol AND
+                                          port will be matched.
                                         x-kubernetes-int-or-string: true
                                       protocol:
                                         default: TCP
-                                        description: The protocol (TCP, UDP, or SCTP) which traffic must match. If not specified, this field defaults to TCP.
+                                        description: The protocol (TCP, UDP, or SCTP)
+                                          which traffic must match. If not specified,
+                                          this field defaults to TCP.
                                         type: string
                                     type: object
                                   type: array
                               type: object
                             type: array
                           podSelector:
-                            description: Selects the pods to which this NetworkPolicy object applies. The array of ingress rules is applied to any pods selected by this field. Multiple network policies can select the same set of pods. In this case, the ingress rules for each are combined additively. This field is NOT optional and follows standard label selector semantics. An empty podSelector matches all pods in this namespace.
+                            description: Selects the pods to which this NetworkPolicy
+                              object applies. The array of ingress rules is applied
+                              to any pods selected by this field. Multiple network policies
+                              can select the same set of pods. In this case, the ingress
+                              rules for each are combined additively. This field is
+                              NOT optional and follows standard label selector semantics.
+                              An empty podSelector matches all pods in this namespace.
                             properties:
                               matchExpressions:
-                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
                                 items:
-                                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                  description: A label selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
                                   properties:
                                     key:
-                                      description: key is the label key that the selector applies to.
+                                      description: key is the label key that the selector
+                                        applies to.
                                       type: string
                                     operator:
-                                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      description: operator represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists and DoesNotExist.
                                       type: string
                                     values:
-                                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                      description: values is an array of string values.
+                                        If the operator is In or NotIn, the values array
+                                        must be non-empty. If the operator is Exists
+                                        or DoesNotExist, the values array must be empty.
+                                        This array is replaced during a strategic merge
+                                        patch.
                                       items:
                                         type: string
                                       type: array
@@ -1800,14 +2775,32 @@ spec:
                               matchLabels:
                                 additionalProperties:
                                   type: string
-                                description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                description: matchLabels is a map of {key,value} pairs.
+                                  A single {key,value} in the matchLabels map is equivalent
+                                  to an element of matchExpressions, whose key field
+                                  is "key", the operator is "In", and the values array
+                                  contains only "value". The requirements are ANDed.
                                 type: object
                             type: object
                             x-kubernetes-map-type: atomic
                           policyTypes:
-                            description: List of rule types that the NetworkPolicy relates to. Valid options are ["Ingress"], ["Egress"], or ["Ingress", "Egress"]. If this field is not specified, it will default based on the existence of Ingress or Egress rules; policies that contain an Egress section are assumed to affect Egress, and all policies (whether or not they contain an Ingress section) are assumed to affect Ingress. If you want to write an egress-only policy, you must explicitly specify policyTypes [ "Egress" ]. Likewise, if you want to write a policy that specifies that no egress is allowed, you must specify a policyTypes value that include "Egress" (since such a policy would not include an Egress section and would otherwise default to just [ "Ingress" ]). This field is beta-level in 1.8
+                            description: List of rule types that the NetworkPolicy relates
+                              to. Valid options are ["Ingress"], ["Egress"], or ["Ingress",
+                              "Egress"]. If this field is not specified, it will default
+                              based on the existence of Ingress or Egress rules; policies
+                              that contain an Egress section are assumed to affect Egress,
+                              and all policies (whether or not they contain an Ingress
+                              section) are assumed to affect Ingress. If you want to
+                              write an egress-only policy, you must explicitly specify
+                              policyTypes [ "Egress" ]. Likewise, if you want to write
+                              a policy that specifies that no egress is allowed, you
+                              must specify a policyTypes value that include "Egress"
+                              (since such a policy would not include an Egress section
+                              and would otherwise default to just [ "Ingress" ]). This
+                              field is beta-level in 1.8
                             items:
-                              description: PolicyType string describes the NetworkPolicy type This type is beta-level in 1.8
+                              description: PolicyType string describes the NetworkPolicy
+                                type This type is beta-level in 1.8
                               type: string
                             type: array
                         required:
@@ -1818,7 +2811,11 @@ spec:
                 nodeSelector:
                   additionalProperties:
                     type: string
-                  description: Specifies the label to control the placement of pods on a given pool of worker nodes. All namespaces created within the Tenant will have the node selector annotation. This annotation tells the Kubernetes scheduler to place pods on the nodes having the selector label. Optional.
+                  description: Specifies the label to control the placement of pods
+                    on a given pool of worker nodes. All namespaces created within the
+                    Tenant will have the node selector annotation. This annotation tells
+                    the Kubernetes scheduler to place pods on the nodes having the selector
+                    label. Optional.
                   type: object
                 owners:
                   description: Specifies the owners of the Tenant. Mandatory.
@@ -1828,12 +2825,14 @@ spec:
                         default:
                           - admin
                           - capsule-namespace-deleter
-                        description: Defines additional cluster-roles for the specific Owner.
+                        description: Defines additional cluster-roles for the specific
+                          Owner.
                         items:
                           type: string
                         type: array
                       kind:
-                        description: Kind of tenant owner. Possible values are "User", "Group", and "ServiceAccount"
+                        description: Kind of tenant owner. Possible values are "User",
+                          "Group", and "ServiceAccount"
                         enum:
                           - User
                           - Group
@@ -1852,6 +2851,8 @@ spec:
                                 - StorageClasses
                                 - IngressClasses
                                 - PriorityClasses
+                                - RuntimeClasses
+                                - PersistentVolumes
                               type: string
                             operations:
                               items:
@@ -1872,10 +2873,15 @@ spec:
                     type: object
                   type: array
                 preventDeletion:
-                  description: Prevent accidental deletion of the Tenant. When enabled, the deletion request will be declined.
+                  description: Prevent accidental deletion of the Tenant. When enabled,
+                    the deletion request will be declined.
                   type: boolean
                 priorityClasses:
-                  description: Specifies the allowed priorityClasses assigned to the Tenant. Capsule assures that all Pods resources created in the Tenant can use only one of the allowed PriorityClasses. A default value can be specified, and all the Pod resources created will inherit the declared class. Optional.
+                  description: Specifies the allowed priorityClasses assigned to the
+                    Tenant. Capsule assures that all Pods resources created in the Tenant
+                    can use only one of the allowed PriorityClasses. A default value
+                    can be specified, and all the Pod resources created will inherit
+                    the declared class. Optional.
                   properties:
                     allowed:
                       items:
@@ -1886,18 +2892,28 @@ spec:
                     default:
                       type: string
                     matchExpressions:
-                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
                       items:
-                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the key
+                          and values.
                         properties:
                           key:
-                            description: key is the label key that the selector applies to.
+                            description: key is the label key that the selector applies
+                              to.
                             type: string
                           operator:
-                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                            description: operator represents a key's relationship to
+                              a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
                             type: string
                           values:
-                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a strategic
+                              merge patch.
                             items:
                               type: string
                             type: array
@@ -1909,16 +2925,26 @@ spec:
                     matchLabels:
                       additionalProperties:
                         type: string
-                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
                       type: object
                   type: object
                   x-kubernetes-map-type: atomic
                 resourceQuotas:
-                  description: Specifies a list of ResourceQuota resources assigned to the Tenant. The assigned values are inherited by any namespace created in the Tenant. The Capsule operator aggregates ResourceQuota at Tenant level, so that the hard quota is never crossed for the given Tenant. This permits the Tenant owner to consume resources in the Tenant regardless of the namespace. Optional.
+                  description: Specifies a list of ResourceQuota resources assigned
+                    to the Tenant. The assigned values are inherited by any namespace
+                    created in the Tenant. The Capsule operator aggregates ResourceQuota
+                    at Tenant level, so that the hard quota is never crossed for the
+                    given Tenant. This permits the Tenant owner to consume resources
+                    in the Tenant regardless of the namespace. Optional.
                   properties:
                     items:
                       items:
-                        description: ResourceQuotaSpec defines the desired hard limits to enforce for Quota.
+                        description: ResourceQuotaSpec defines the desired hard limits
+                          to enforce for Quota.
                         properties:
                           hard:
                             additionalProperties:
@@ -1927,24 +2953,40 @@ spec:
                                 - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: 'hard is the set of desired hard limits for each named resource. More info: https://kubernetes.io/docs/concepts/policy/resource-quotas/'
+                            description: 'hard is the set of desired hard limits for
+                            each named resource. More info: https://kubernetes.io/docs/concepts/policy/resource-quotas/'
                             type: object
                           scopeSelector:
-                            description: scopeSelector is also a collection of filters like scopes that must match each object tracked by a quota but expressed using ScopeSelectorOperator in combination with possible values. For a resource to match, both scopes AND scopeSelector (if specified in spec), must be matched.
+                            description: scopeSelector is also a collection of filters
+                              like scopes that must match each object tracked by a quota
+                              but expressed using ScopeSelectorOperator in combination
+                              with possible values. For a resource to match, both scopes
+                              AND scopeSelector (if specified in spec), must be matched.
                             properties:
                               matchExpressions:
-                                description: A list of scope selector requirements by scope of the resources.
+                                description: A list of scope selector requirements by
+                                  scope of the resources.
                                 items:
-                                  description: A scoped-resource selector requirement is a selector that contains values, a scope name, and an operator that relates the scope name and values.
+                                  description: A scoped-resource selector requirement
+                                    is a selector that contains values, a scope name,
+                                    and an operator that relates the scope name and
+                                    values.
                                   properties:
                                     operator:
-                                      description: Represents a scope's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist.
+                                      description: Represents a scope's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists, DoesNotExist.
                                       type: string
                                     scopeName:
-                                      description: The name of the scope that the selector applies to.
+                                      description: The name of the scope that the selector
+                                        applies to.
                                       type: string
                                     values:
-                                      description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                      description: An array of string values. If the
+                                        operator is In or NotIn, the values array must
+                                        be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This array is
+                                        replaced during a strategic merge patch.
                                       items:
                                         type: string
                                       type: array
@@ -1956,23 +2998,30 @@ spec:
                             type: object
                             x-kubernetes-map-type: atomic
                           scopes:
-                            description: A collection of filters that must match each object tracked by a quota. If not specified, the quota matches all objects.
+                            description: A collection of filters that must match each
+                              object tracked by a quota. If not specified, the quota
+                              matches all objects.
                             items:
-                              description: A ResourceQuotaScope defines a filter that must match each object tracked by a quota
+                              description: A ResourceQuotaScope defines a filter that
+                                must match each object tracked by a quota
                               type: string
                             type: array
                         type: object
                       type: array
                     scope:
                       default: Tenant
-                      description: Define if the Resource Budget should compute resource across all Namespaces in the Tenant or individually per cluster. Default is Tenant
+                      description: Define if the Resource Budget should compute resource
+                        across all Namespaces in the Tenant or individually per cluster.
+                        Default is Tenant
                       enum:
                         - Tenant
                         - Namespace
                       type: string
                   type: object
                 runtimeClasses:
-                  description: Specifies the allowed RuntimeClasses assigned to the Tenant. Capsule assures that all Pods resources created in the Tenant can use only one of the allowed RuntimeClasses. Optional.
+                  description: Specifies the allowed RuntimeClasses assigned to the
+                    Tenant. Capsule assures that all Pods resources created in the Tenant
+                    can use only one of the allowed RuntimeClasses. Optional.
                   properties:
                     allowed:
                       items:
@@ -1981,18 +3030,28 @@ spec:
                     allowedRegex:
                       type: string
                     matchExpressions:
-                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
                       items:
-                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the key
+                          and values.
                         properties:
                           key:
-                            description: key is the label key that the selector applies to.
+                            description: key is the label key that the selector applies
+                              to.
                             type: string
                           operator:
-                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                            description: operator represents a key's relationship to
+                              a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
                             type: string
                           values:
-                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a strategic
+                              merge patch.
                             items:
                               type: string
                             type: array
@@ -2004,15 +3063,21 @@ spec:
                     matchLabels:
                       additionalProperties:
                         type: string
-                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
                       type: object
                   type: object
                   x-kubernetes-map-type: atomic
                 serviceOptions:
-                  description: Specifies options for the Service, such as additional metadata or block of certain type of Services. Optional.
+                  description: Specifies options for the Service, such as additional
+                    metadata or block of certain type of Services. Optional.
                   properties:
                     additionalMetadata:
-                      description: Specifies additional labels and annotations the Capsule operator places on any Service resource in the Tenant. Optional.
+                      description: Specifies additional labels and annotations the Capsule
+                        operator places on any Service resource in the Tenant. Optional.
                       properties:
                         annotations:
                           additionalProperties:
@@ -2028,19 +3093,24 @@ spec:
                       properties:
                         externalName:
                           default: true
-                          description: Specifies if ExternalName service type resources are allowed for the Tenant. Default is true. Optional.
+                          description: Specifies if ExternalName service type resources
+                            are allowed for the Tenant. Default is true. Optional.
                           type: boolean
                         loadBalancer:
                           default: true
-                          description: Specifies if LoadBalancer service type resources are allowed for the Tenant. Default is true. Optional.
+                          description: Specifies if LoadBalancer service type resources
+                            are allowed for the Tenant. Default is true. Optional.
                           type: boolean
                         nodePort:
                           default: true
-                          description: Specifies if NodePort service type resources are allowed for the Tenant. Default is true. Optional.
+                          description: Specifies if NodePort service type resources
+                            are allowed for the Tenant. Default is true. Optional.
                           type: boolean
                       type: object
                     externalIPs:
-                      description: Specifies the external IPs that can be used in Services with type ClusterIP. An empty list means no IPs are allowed. Optional.
+                      description: Specifies the external IPs that can be used in Services
+                        with type ClusterIP. An empty list means no IPs are allowed.
+                        Optional.
                       properties:
                         allowed:
                           items:
@@ -2052,7 +3122,11 @@ spec:
                       type: object
                   type: object
                 storageClasses:
-                  description: Specifies the allowed StorageClasses assigned to the Tenant. Capsule assures that all PersistentVolumeClaim resources created in the Tenant can use only one of the allowed StorageClasses. A default value can be specified, and all the PersistentVolumeClaim resources created will inherit the declared class. Optional.
+                  description: Specifies the allowed StorageClasses assigned to the
+                    Tenant. Capsule assures that all PersistentVolumeClaim resources
+                    created in the Tenant can use only one of the allowed StorageClasses.
+                    A default value can be specified, and all the PersistentVolumeClaim
+                    resources created will inherit the declared class. Optional.
                   properties:
                     allowed:
                       items:
@@ -2063,18 +3137,28 @@ spec:
                     default:
                       type: string
                     matchExpressions:
-                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
                       items:
-                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the key
+                          and values.
                         properties:
                           key:
-                            description: key is the label key that the selector applies to.
+                            description: key is the label key that the selector applies
+                              to.
                             type: string
                           operator:
-                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                            description: operator represents a key's relationship to
+                              a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
                             type: string
                           values:
-                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a strategic
+                              merge patch.
                             items:
                               type: string
                             type: array
@@ -2086,7 +3170,11 @@ spec:
                     matchLabels:
                       additionalProperties:
                         type: string
-                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
                       type: object
                   type: object
                   x-kubernetes-map-type: atomic
@@ -2106,7 +3194,8 @@ spec:
                   type: integer
                 state:
                   default: Active
-                  description: The operational state of the Tenant. Possible values are "Active", "Cordoned".
+                  description: The operational state of the Tenant. Possible values
+                    are "Active", "Cordoned".
                   enum:
                     - Cordoned
                     - Active

--- a/config/crd/bases/capsule.clastix.io_tenants.yaml
+++ b/config/crd/bases/capsule.clastix.io_tenants.yaml
@@ -2840,6 +2840,8 @@ spec:
                             - StorageClasses
                             - IngressClasses
                             - PriorityClasses
+                            - RuntimeClasses
+                            - PersistentVolumes
                             type: string
                           operations:
                             items:

--- a/config/install.yaml
+++ b/config/install.yaml
@@ -2416,6 +2416,8 @@ spec:
                             - StorageClasses
                             - IngressClasses
                             - PriorityClasses
+                            - RuntimeClasses
+                            - PersistentVolumes
                             type: string
                           operations:
                             items:

--- a/docs/content/general/crds-apis.md
+++ b/docs/content/general/crds-apis.md
@@ -3081,7 +3081,7 @@ TenantSpec defines the desired state of Tenant.
         <td>
           <br/>
           <br/>
-            <i>Enum</i>: Nodes, StorageClasses, IngressClasses, PriorityClasses<br/>
+            <i>Enum</i>: Nodes, StorageClasses, IngressClasses, PriorityClasses, RuntimeClasses, PersistentVolumes<br/>
         </td>
         <td>true</td>
       </tr><tr>


### PR DESCRIPTION
<!--
# General contribution criteria

Thanks for spending some time for improving and fixing Capsule!

We're still working on the outline of the contribution guidelines but we're
following ourselves these points:

- reference a previously opened issue: https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls#issues-and-pull-requests 
- including a sentence or two in the commit description for the
  changelog/release notes
- splitting changes into several and documented small commits
- limit the git subject to 50 characters and write as the continuation of the
  sentence "If applied, this commit will ..."
- explain what and why in the body, if more than a trivial change, wrapping at
  72 characters

If you have any issue or question, reach out us!
https://clastix.slack.com >>> #capsule channel 
-->

Adds the RuntimeClass field to the owner API. I think this change should be possible without any problems. Required for https://github.com/clastix/capsule-proxy/issues/260. 
