### PR TITLE
feat(helm): add securityContexts to jobs

### DIFF
--- a/charts/capsule/Chart.yaml
+++ b/charts/capsule/Chart.yaml
@@ -21,7 +21,7 @@ sources:
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.3.3
+version: 0.3.4
 
 # This is the version number of the application being deployed.
 # This version number should be incremented each time you make changes to the application.

--- a/charts/capsule/templates/post-install-job.yaml
+++ b/charts/capsule/templates/post-install-job.yaml
@@ -45,5 +45,11 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
       serviceAccountName: {{ include "capsule.serviceAccountName" . }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/charts/capsule/templates/pre-delete-job.yaml
+++ b/charts/capsule/templates/pre-delete-job.yaml
@@ -47,4 +47,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
       serviceAccountName: {{ include "capsule.serviceAccountName" . }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}


### PR DESCRIPTION
local test:
```bash
~ kind create cluster
...

~ k cluster-info
Kubernetes control plane is running at https://127.0.0.1:61015
CoreDNS is running at https://127.0.0.1:61015/api/v1/namespaces/kube-system/services/kube-dns:dns/proxy

To further debug and diagnose cluster problems, use 'kubectl cluster-info dump'.

~ helm install capsule . -n capsule-system --create-namespace 
NAME: capsule
LAST DEPLOYED: Tue Feb 14 17:34:56 2023
NAMESPACE: capsule-system
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
...

~ k create -f - << EOF
apiVersion: capsule.clastix.io/v1beta2
kind: Tenant
metadata:
  name: oil
spec:
  owners:
  - name: alice
    kind: User
EOF
tenant.capsule.clastix.io/oil created

~ k get tenants
NAME   STATE    NAMESPACE QUOTA   NAMESPACE COUNT   NODE SELECTOR   AGE
oil    Active                     0                                 6s

~ ../../hack/create-user.sh alice oil
creating certs in TMPDIR /var/folders/c7/78_t4pvj5zd2qrcwgq05h7_40000gn/T/tmp.EC4Ogyzl
merging groups /O=capsule.clastix.io
Generating RSA private key, 2048 bit long modulus
......................................................................+++
.+++
e is 65537 (0x10001)
certificatesigningrequest.certificates.k8s.io/alice-oil created
certificatesigningrequest.certificates.k8s.io/alice-oil approved
kubeconfig file is: alice-oil.kubeconfig
to use it as alice export KUBECONFIG=alice-oil.kubeconfig

~ export KUBECONFIG=alice-oil.kubeconfig
~ k create namespace oil-development
namespace/oil-development created

~ export KUBECONFIG=
~ k get tenant oil
NAME   STATE    NAMESPACE QUOTA   NAMESPACE COUNT   NODE SELECTOR   AGE
oil    Active                     1                                 31s

```