### PR TITLE
fix(helm): move imagePullSecrets to root values

### DIFF
--- a/charts/capsule/Chart.yaml
+++ b/charts/capsule/Chart.yaml
@@ -21,7 +21,7 @@ sources:
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.3.4
+version: 0.3.5
 
 # This is the version number of the application being deployed.
 # This version number should be incremented each time you make changes to the application.

--- a/charts/capsule/README.md
+++ b/charts/capsule/README.md
@@ -66,6 +66,7 @@ Here the values you can override:
 | certManager.generateCertificates | bool | `false` | Specifies whether capsule webhooks certificates should be generated using cert-manager |
 | customAnnotations | object | `{}` | Additional annotations which will be added to all resources created by Capsule helm chart |
 | customLabels | object | `{}` | Additional labels which will be added to all resources created by Capsule helm chart |
+| imagePullSecrets | list | `[]` | Configuration for `imagePullSecrets` so that you can use a private images registry. |
 | jobs.image.pullPolicy | string | `"IfNotPresent"` | Set the image pull policy of the helm chart job |
 | jobs.image.repository | string | `"clastix/kubectl"` | Set the image repository of the helm chart job |
 | jobs.image.tag | string | `""` | Set the image tag of the helm chart job |
@@ -94,7 +95,6 @@ Here the values you can override:
 | manager.image.pullPolicy | string | `"IfNotPresent"` | Set the image pull policy. |
 | manager.image.repository | string | `"clastix/capsule"` | Set the image repository of the capsule. |
 | manager.image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
-| manager.imagePullSecrets | list | `[]` | Configuration for `imagePullSecrets` so that you can use a private images registry. |
 | manager.kind | string | `"Deployment"` | Set the controller deployment mode as `Deployment` or `DaemonSet`. |
 | manager.livenessProbe | object | `{"httpGet":{"path":"/healthz","port":10080}}` | Configure the liveness probe using Deployment probe spec |
 | manager.options.capsuleUserGroups | list | `["capsule.clastix.io"]` | Override the Capsule user groups |

--- a/charts/capsule/values.yaml
+++ b/charts/capsule/values.yaml
@@ -25,9 +25,6 @@ manager:
     # -- Overrides the image tag whose default is the chart appVersion.
     tag: ''
 
-  # -- Configuration for `imagePullSecrets` so that you can use a private images registry.
-  imagePullSecrets: []
-
   # -- Specifies if the container should be started in hostNetwork mode.
   #
   # Required for use in some managed kubernetes clusters (such as AWS EKS) with custom
@@ -67,6 +64,9 @@ manager:
     requests:
       cpu: 200m
       memory: 128Mi
+
+# -- Configuration for `imagePullSecrets` so that you can use a private images registry.
+imagePullSecrets: []
 
 # -- Annotations to add to the capsule pod.
 podAnnotations: {}


### PR DESCRIPTION
In templates daemonset.yaml/deployment.yaml/post-install-job.yaml/pre-delete-job.yaml used `.Values.imagePullSecrets`, not `.Values.manager.imagePullSecrets `
