### PR TITLE
feat: allow customization of the webhook port

### DIFF
--- a/charts/capsule/Chart.yaml
+++ b/charts/capsule/Chart.yaml
@@ -21,7 +21,7 @@ sources:
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.3.6
+version: 0.4.0
 
 # This is the version number of the application being deployed.
 # This version number should be incremented each time you make changes to the application.

--- a/charts/capsule/README.md
+++ b/charts/capsule/README.md
@@ -107,6 +107,7 @@ Here the values you can override:
 | manager.resources.limits.memory | string | `"128Mi"` |  |
 | manager.resources.requests.cpu | string | `"200m"` |  |
 | manager.resources.requests.memory | string | `"128Mi"` |  |
+| manager.webhookPort | int | `9443` | Set an alternative to the default container port.  Useful for use in some kubernetes clusters (such as GKE Private) with aggregator routing turned on, because pod ports have to be opened manually on the firewall side |
 
 ### ServiceMonitor Parameters
 

--- a/charts/capsule/templates/daemonset.yaml
+++ b/charts/capsule/templates/daemonset.yaml
@@ -60,6 +60,7 @@ spec:
           command:
           - /manager
           args:
+          - --webhook-port={{ .Values.manager.webhookPort }}
           - --enable-leader-election
           - --zap-log-level={{ default 4 .Values.manager.options.logLevel }}
           - --configuration-name=default
@@ -72,7 +73,7 @@ spec:
                 fieldPath: metadata.namespace
           ports:
             - name: webhook-server
-              containerPort: 9443
+              containerPort: {{ .Values.manager.webhookPort }}
               protocol: TCP
             - name: metrics
               containerPort: 8080

--- a/charts/capsule/templates/deployment.yaml
+++ b/charts/capsule/templates/deployment.yaml
@@ -59,6 +59,7 @@ spec:
           command:
           - /manager
           args:
+          - --webhook-port={{ .Values.manager.webhookPort }}
           - --enable-leader-election
           - --zap-log-level={{ default 4 .Values.manager.options.logLevel }}
           - --configuration-name=default
@@ -71,7 +72,7 @@ spec:
                 fieldPath: metadata.namespace
           ports:
             - name: webhook-server
-              containerPort: 9443
+              containerPort: {{ .Values.manager.webhookPort }}
               protocol: TCP
             - name: metrics
               containerPort: 8080

--- a/charts/capsule/templates/webhook-service.yaml
+++ b/charts/capsule/templates/webhook-service.yaml
@@ -13,7 +13,7 @@ spec:
   - port: 443
     name: https
     protocol: TCP
-    targetPort: 9443
+    targetPort: {{ .Values.manager.webhookPort }}
   selector:
     {{- include "capsule.selectorLabels" . | nindent 4 }}
   sessionAffinity: None

--- a/charts/capsule/values.yaml
+++ b/charts/capsule/values.yaml
@@ -32,6 +32,13 @@ manager:
   # with pods' IP CIDR and admission webhooks are not working
   hostNetwork: false
 
+  # -- Set an alternative to the default container port.
+  #
+  # Useful for use in some kubernetes clusters (such as GKE Private) with
+  # aggregator routing turned on, because pod ports have to be opened manually
+  # on the firewall side
+  webhookPort: 9443
+
   # Additional Capsule Controller Options
   options:
     # -- Set the log verbosity of the capsule with a value from 1 to 10

--- a/main.go
+++ b/main.go
@@ -102,8 +102,11 @@ func main() {
 
 	var metricsAddr, namespace, configurationName string
 
+	var webhookPort int
+
 	var goFlagSet goflag.FlagSet
 
+	flag.IntVar(&webhookPort, "webhook-port", 9443, "The port the webhook server binds to.")
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. "+
@@ -142,7 +145,7 @@ func main() {
 	manager, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,
 		MetricsBindAddress:     metricsAddr,
-		Port:                   9443,
+		Port:                   webhookPort,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "42c733ea.clastix.capsule.io",
 		HealthProbeBindAddress: ":10080",


### PR DESCRIPTION
<!--
# General contribution criteria

Thanks for spending some time for improving and fixing Capsule!

We're still working on the outline of the contribution guidelines but we're
following ourselves these points:

- reference a previously opened issue: https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls#issues-and-pull-requests 
- including a sentence or two in the commit description for the
  changelog/release notes
- splitting changes into several and documented small commits
- limit the git subject to 50 characters and write as the continuation of the
  sentence "If applied, this commit will ..."
- explain what and why in the body, if more than a trivial change, wrapping at
  72 characters

If you have any issue or question, reach out us!
https://clastix.slack.com >>> #capsule channel 
-->

Fixes #715

In some networking contexts, operators may need to use a custom webhook port. This PR add the `webhook-port` CLI parameter, sets its default value to `9443` and passes it down to the manager. It also adds the `manager.webhookPort` Helm value to the chart and bindings to the service, deployment and daemonset resources.