### PR TITLE
chore(helm): bump up the appVersion

### DIFF
--- a/charts/capsule/Chart.yaml
+++ b/charts/capsule/Chart.yaml
@@ -21,8 +21,8 @@ sources:
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.3.5
+version: 0.3.6
 
 # This is the version number of the application being deployed.
 # This version number should be incremented each time you make changes to the application.
-appVersion: 0.2.1
+appVersion: 0.2.2


### PR DESCRIPTION
The latest tag in capsule is `0.2.2` but the appVersion in the chart.yaml is still pointing to the previous release i.e. `0.2.1` so incremented the appVersion.