### PR TITLE
fix: update golang to 1.19

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.18'
+          go-version: '1.19'
       - run: make installer
       - name: Checking if YAML installer file is not aligned
         run: if [[ $(git diff | wc -l) -gt 0 ]]; then echo ">>> Untracked generated files have not been committed" && git --no-pager diff && exit 1; fi

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -40,7 +40,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.18'
+          go-version: '1.19'
       - run: make manifests
       - name: Checking if manifests are disaligned
         run: test -z "$(git diff 2> /dev/null)"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.18 as builder
+FROM golang:1.19 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/docs/content/contributing/development.md
+++ b/docs/content/contributing/development.md
@@ -4,7 +4,7 @@
 
 Make sure you have these tools installed:
 
-- [Go 1.18+](https://golang.org/dl/)
+- [Go 1.19+](https://golang.org/dl/)
 - [Operator SDK 1.7.2+](https://github.com/operator-framework/operator-sdk), or [Kubebuilder](https://github.com/kubernetes-sigs/kubebuilder)
 - [KinD](https://github.com/kubernetes-sigs/kind) or [k3d](https://k3d.io/), with `kubectl`
 - [ngrok](https://ngrok.com/) (if you want to run locally with remote Kubernetes)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/clastix/capsule
 
-go 1.18
+go 1.19
 
 require (
 	github.com/go-logr/logr v1.2.0


### PR DESCRIPTION
update capsule to golang 1.19 to allow for easier recompile using boringcrypto which was added to main in golang 1.19
<!--
# General contribution criteria

Thanks for spending some time for improving and fixing Capsule!

We're still working on the outline of the contribution guidelines but we're
following ourselves these points:

- reference a previously opened issue: https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls#issues-and-pull-requests 
- including a sentence or two in the commit description for the
  changelog/release notes
- splitting changes into several and documented small commits
- limit the git subject to 50 characters and write as the continuation of the
  sentence "If applied, this commit will ..."
- explain what and why in the body, if more than a trivial change, wrapping at
  72 characters

If you have any issue or question, reach out us!
https://clastix.slack.com >>> #capsule channel 
-->
