### PR TITLE
WIP: feat: managed mutation webhook

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,8 @@ dev-setup:
 		    {'op': 'replace', 'path': '/webhooks/0/clientConfig', 'value':{'url':\"$${WEBHOOK_URL}/defaults\",'caBundle':\"$${CA_BUNDLE}\"}},\
 			{'op': 'replace', 'path': '/webhooks/1/clientConfig', 'value':{'url':\"$${WEBHOOK_URL}/defaults\",'caBundle':\"$${CA_BUNDLE}\"}},\
 			{'op': 'replace', 'path': '/webhooks/2/clientConfig', 'value':{'url':\"$${WEBHOOK_URL}/defaults\",'caBundle':\"$${CA_BUNDLE}\"}},\
-			{'op': 'replace', 'path': '/webhooks/3/clientConfig', 'value':{'url':\"$${WEBHOOK_URL}/namespace-owner-reference\",'caBundle':\"$${CA_BUNDLE}\"}}\
+			{'op': 'replace', 'path': '/webhooks/3/clientConfig', 'value':{'url':\"$${WEBHOOK_URL}/managed\",'caBundle':\"$${CA_BUNDLE}\"}},\
+			{'op': 'replace', 'path': '/webhooks/4/clientConfig', 'value':{'url':\"$${WEBHOOK_URL}/namespace-owner-reference\",'caBundle':\"$${CA_BUNDLE}\"}}\
 		]" && \
 	kubectl patch ValidatingWebhookConfiguration capsule-validating-webhook-configuration \
 		--type='json' -p="[\
@@ -154,7 +155,8 @@ dev-setup:
 			{'op': 'replace', 'path': '/webhooks/5/clientConfig', 'value':{'url':\"$${WEBHOOK_URL}/pods\",'caBundle':\"$${CA_BUNDLE}\"}},\
 			{'op': 'replace', 'path': '/webhooks/6/clientConfig', 'value':{'url':\"$${WEBHOOK_URL}/persistentvolumeclaims\",'caBundle':\"$${CA_BUNDLE}\"}},\
 			{'op': 'replace', 'path': '/webhooks/7/clientConfig', 'value':{'url':\"$${WEBHOOK_URL}/services\",'caBundle':\"$${CA_BUNDLE}\"}},\
-			{'op': 'replace', 'path': '/webhooks/8/clientConfig', 'value':{'url':\"$${WEBHOOK_URL}/tenants\",'caBundle':\"$${CA_BUNDLE}\"}}\
+			{'op': 'replace', 'path': '/webhooks/8/clientConfig', 'value':{'url':\"$${WEBHOOK_URL}/tenantresource-objects\",'caBundle':\"$${CA_BUNDLE}\"}},\
+			{'op': 'replace', 'path': '/webhooks/9/clientConfig', 'value':{'url':\"$${WEBHOOK_URL}/tenants\",'caBundle':\"$${CA_BUNDLE}\"}}\
 		]" && \
 	kubectl patch crd tenants.capsule.clastix.io \
 		--type='json' -p="[\
@@ -174,6 +176,9 @@ docker-build: test
  							 --build-arg GIT_REPO=$(GIT_REPO) \
  							 --build-arg GIT_LAST_TAG=$(VERSION) \
  							 --build-arg BUILD_DATE=$(BUILD_DATE)
+
+docker-load:
+	kind load docker-image --name capsule ${IMG} 
 
 # Push the docker image
 docker-push:

--- a/charts/capsule/templates/mutatingwebhookconfiguration.yaml
+++ b/charts/capsule/templates/mutatingwebhookconfiguration.yaml
@@ -91,7 +91,37 @@ webhooks:
   namespaceSelector:
   {{- toYaml .namespaceSelector | nindent 4}}
   sideEffects: None
-{{- end }}  
+{{- end }}
+{{- if .Values.webhooks.managed.enabled }}
+- admissionReviewVersions:
+    - v1
+    - v1beta1
+  clientConfig:
+{{- if not .Values.certManager.generateCertificates }}
+    caBundle: Cg==
+{{- end }}
+    service:
+      name: {{ include "capsule.fullname" . }}-webhook-service
+      namespace: {{ .Release.Namespace }}
+      path: /managed
+      port: 443
+  name: managed.capsule.clastix.io
+  rules:
+  - apiGroups:
+    - '*'
+    apiVersions:
+    - '*'
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - '*'
+  failurePolicy: {{ .Values.webhooks.managed.failurePolicy }}
+  matchPolicy: Equivalent
+  namespaceSelector:
+  {{- toYaml .Values.webhooks.managed.namespaceSelector | nindent 4}}
+  sideEffects: None
+{{- end }}
 - admissionReviewVersions:
     - v1
     - v1beta1

--- a/charts/capsule/values.yaml
+++ b/charts/capsule/values.yaml
@@ -225,7 +225,13 @@ webhooks:
         matchExpressions:
           - key: capsule.clastix.io/tenant
             operator: Exists
-
+    managed:
+      enabled: true
+      failurePolicy: Fail
+      namespaceSelector:
+        matchExpressions:
+          - key: capsule.clastix.io/tenant
+            operator: Exists
 
 # -- Timeout in seconds for mutating webhooks
 mutatingWebhooksTimeoutSeconds: 30

--- a/config/install.yaml
+++ b/config/install.yaml
@@ -2769,7 +2769,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: clastix/capsule:v0.3.3
+        image: clastix/capsule:v0.2.1
         imagePullPolicy: IfNotPresent
         name: manager
         ports:
@@ -2887,6 +2887,31 @@ webhooks:
     - UPDATE
     resources:
     - ingresses
+    scope: Namespaced
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: capsule-webhook-service
+      namespace: capsule-system
+      path: /managed
+  failurePolicy: Fail
+  name: managed.capsule.clastix.io
+  namespaceSelector:
+    matchExpressions:
+    - key: capsule.clastix.io/tenant
+      operator: Exists
+  rules:
+  - apiGroups:
+    - '*'
+    apiVersions:
+    - '*'
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - '*'
     scope: Namespaced
   sideEffects: None
 - admissionReviewVersions:

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -7,4 +7,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: clastix/capsule
-  newTag: v0.3.3
+  newTag: v0.2.1

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -70,6 +70,26 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
+      path: /managed
+  failurePolicy: Fail
+  name: managed.capsule.clastix.io
+  rules:
+  - apiGroups:
+    - '*'
+    apiVersions:
+    - '*'
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - '*'
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
       path: /namespace-owner-reference
   failurePolicy: Fail
   name: owner.namespace.capsule.clastix.io

--- a/config/webhook/patch_mutating_ns_selector.yaml
+++ b/config/webhook/patch_mutating_ns_selector.yaml
@@ -17,6 +17,18 @@
       - key: capsule.clastix.io/tenant
         operator: Exists
 - op: add
+  path: /webhooks/3/namespaceSelector
+  value:
+    matchExpressions:
+      - key: capsule.clastix.io/tenant
+        operator: Exists
+- op: add
+  path: /webhooks/4/namespaceSelector
+  value:
+    matchExpressions:
+      - key: capsule.clastix.io/tenant
+        operator: Exists
+- op: add
   path: /webhooks/0/rules/0/scope
   value: Namespaced
 - op: add
@@ -24,4 +36,10 @@
   value: Namespaced
 - op: add
   path: /webhooks/2/rules/0/scope
+  value: Namespaced
+- op: add
+  path: /webhooks/3/rules/0/scope
+  value: Namespaced
+- op: add
+  path: /webhooks/4/rules/0/scope
   value: Namespaced

--- a/main.go
+++ b/main.go
@@ -41,6 +41,7 @@ import (
 	"github.com/clastix/capsule/pkg/webhook"
 	"github.com/clastix/capsule/pkg/webhook/defaults"
 	"github.com/clastix/capsule/pkg/webhook/ingress"
+	"github.com/clastix/capsule/pkg/webhook/managed"
 	namespacewebhook "github.com/clastix/capsule/pkg/webhook/namespace"
 	"github.com/clastix/capsule/pkg/webhook/networkpolicy"
 	"github.com/clastix/capsule/pkg/webhook/node"
@@ -238,6 +239,7 @@ func main() {
 		route.Cordoning(tenant.CordoningHandler(cfg), tenant.ResourceCounterHandler(manager.GetClient())),
 		route.Node(utils.InCapsuleGroups(cfg, node.UserMetadataHandler(cfg, kubeVersion))),
 		route.Defaults(defaults.Handler(cfg, kubeVersion)),
+		route.Managed(managed.Handler(cfg, kubeVersion)),
 	)
 
 	nodeWebhookSupported, _ := utils.NodeWebhookSupported(kubeVersion)

--- a/pkg/webhook/managed/handler.go
+++ b/pkg/webhook/managed/handler.go
@@ -1,0 +1,84 @@
+// Copyright 2020-2021 Clastix Labs
+// SPDX-License-Identifier: Apache-2.0
+
+package managed
+
+import (
+	"context"
+	"net/http"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/version"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/clastix/capsule/pkg/configuration"
+	capsulewebhook "github.com/clastix/capsule/pkg/webhook"
+	"github.com/clastix/capsule/pkg/webhook/utils"
+)
+
+type handler struct {
+	cfg     configuration.Configuration
+	version *version.Version
+}
+
+func Handler(cfg configuration.Configuration, version *version.Version) capsulewebhook.Handler {
+	return &handler{
+		cfg:     cfg,
+		version: version,
+	}
+}
+
+func (h *handler) OnCreate(client client.Client, decoder *admission.Decoder, recorder record.EventRecorder) capsulewebhook.Func {
+	return func(ctx context.Context, req admission.Request) *admission.Response {
+		return h.mutate(ctx, req, client, decoder, recorder)
+	}
+}
+
+func (h *handler) OnDelete(client client.Client, decoder *admission.Decoder, recorder record.EventRecorder) capsulewebhook.Func {
+	return func(ctx context.Context, req admission.Request) *admission.Response {
+		return nil
+	}
+}
+
+func (h *handler) OnUpdate(client client.Client, decoder *admission.Decoder, recorder record.EventRecorder) capsulewebhook.Func {
+	return func(ctx context.Context, req admission.Request) *admission.Response {
+		return h.mutate(ctx, req, client, decoder, recorder)
+	}
+}
+
+func (h *handler) mutate(ctx context.Context, req admission.Request, c client.Client, decoder *admission.Decoder, recorder record.EventRecorder) *admission.Response {
+	obj := unstructured.Unstructured{}
+
+	if err := decoder.Decode(req, &obj); err != nil {
+		return utils.ErroredResponse(err)
+	}
+
+	tnt, err := utils.TenantByStatusNamespace(ctx, c, obj.GetNamespace())
+	if err != nil {
+		return utils.ErroredResponse(err)
+	}
+
+	if tnt == nil {
+		return nil
+	}
+
+	labels := obj.GetLabels()
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+	labels["capsule.clastix.io/managed-by"] = tnt.GetName()
+	obj.SetLabels(labels)
+
+	// Marshal Manifest
+	marshaled, err := obj.MarshalJSON()
+	if err != nil {
+		response := admission.Errored(http.StatusInternalServerError, err)
+
+		return &response
+	}
+
+	response := admission.PatchResponseFromRaw(req.Object.Raw, marshaled)
+	return &response
+}

--- a/pkg/webhook/route/managed.go
+++ b/pkg/webhook/route/managed.go
@@ -1,0 +1,26 @@
+// Copyright 2020-2021 Clastix Labs
+// SPDX-License-Identifier: Apache-2.0
+
+package route
+
+import (
+	capsulewebhook "github.com/clastix/capsule/pkg/webhook"
+)
+
+// +kubebuilder:webhook:path=/managed,mutating=true,sideEffects=None,admissionReviewVersions=v1,failurePolicy=fail,groups="*",resources=*,verbs=create;update,versions="*",name=managed.capsule.clastix.io
+
+type managed struct {
+	handlers []capsulewebhook.Handler
+}
+
+func Managed(handler ...capsulewebhook.Handler) capsulewebhook.Webhook {
+	return &managed{handlers: handler}
+}
+
+func (w *managed) GetHandlers() []capsulewebhook.Handler {
+	return w.handlers
+}
+
+func (w *managed) GetPath() string {
+	return "/managed"
+}


### PR DESCRIPTION
<!--
# General contribution criteria

Thanks for spending some time for improving and fixing Capsule!

We're still working on the outline of the contribution guidelines but we're
following ourselves these points:

- reference a previously opened issue: https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls#issues-and-pull-requests 
- including a sentence or two in the commit description for the
  changelog/release notes
- splitting changes into several and documented small commits
- limit the git subject to 50 characters and write as the continuation of the
  sentence "If applied, this commit will ..."
- explain what and why in the body, if more than a trivial change, wrapping at
  72 characters

If you have any issue or question, reach out us!
https://clastix.slack.com >>> #capsule channel 
-->

This webhook adds a managed label to each resource which is created or updated in a capsule namespace. This is required for the capsule-proxy to query any namespaced resource.

 Helps with issues:

  * https://github.com/clastix/capsule-proxy/issues/303
  * https://github.com/clastix/capsule-proxy/issues/185

I have added an enabled switch for the webhook in the chart, since it brings quiet some workload and thee might be users, which don't use the capsule-proxy at all.

What this implementation does not respect, is the handling of existing resources. I would probably just add a simple script to the documentation, which adds the label to all existing resources in all tenant namespaces.
