### PR TITLE
Update CoC by following CNCF CoC

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,5 +1,7 @@
 # Contributor Covenant Code of Conduct
 
+Capsule follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).
+
 ## Our Pledge
 
 We as members, contributors, and leaders pledge to make participation in our
@@ -114,7 +116,7 @@ the community.
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+This Code of Conduct follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md) and is adapted from the [Contributor Covenant][homepage],
 version 2.0, available at
 https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ make helm-docs
 
 Join the community, share and learn from it. You can find all the resources to how to contribute code and docs, connect with people in the [community repository](https://github.com/clastix/capsule-community).
 
+Please read the [code of conduct](CODE_OF_CONDUCT.md).
+
 ## Adopters
 
 See the [ADOPTERS.md](ADOPTERS.md) file for a list of companies that are using Capsule.


### PR DESCRIPTION
This PR updates code of conducts by following the guidelines provided by the [CNCF code of conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).
